### PR TITLE
Better protection of getInstance method

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/ChromeDriverManager.java
@@ -25,18 +25,14 @@ import java.util.List;
  */
 public class ChromeDriverManager extends BrowserManager {
 	
-	public static ChromeDriverManager instance;
+	private static ChromeDriverManager instance;
 	
 	protected ChromeDriverManager() {
 	}
 
-	public static ChromeDriverManager getInstance() {
+	public static synchronized ChromeDriverManager getInstance() {
 		if (instance == null) {
-			synchronized(ChromeDriverManager.class)  {
-				if (instance == null) {
-					instance = new ChromeDriverManager();
-				}
-			}
+			instance = new ChromeDriverManager();
 		}
 		return instance;
 	}

--- a/src/main/java/io/github/bonigarcia/wdm/InternetExplorerDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/InternetExplorerDriverManager.java
@@ -30,13 +30,9 @@ public class InternetExplorerDriverManager extends BrowserManager {
 	protected InternetExplorerDriverManager() {
 	}
 
-	public static InternetExplorerDriverManager getInstance() {
+	public static synchronized InternetExplorerDriverManager getInstance() {
 		if (instance == null) {
-			synchronized(InternetExplorerDriverManager.class)  {
-				if (instance == null) {
-					instance = new InternetExplorerDriverManager();
-				}
-			}
+			instance = new InternetExplorerDriverManager();
 		}
 		return instance;
 	}

--- a/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
@@ -38,13 +38,9 @@ public class OperaDriverManager extends BrowserManager {
 	protected OperaDriverManager() {
 	}
 
-	public static OperaDriverManager getInstance() {
+	public static synchronized OperaDriverManager getInstance() {
 		if (instance == null) {
-			synchronized(OperaDriverManager.class)  {
-				if (instance == null) {
-					instance = new OperaDriverManager();
-				}
-			}
+			instance = new OperaDriverManager();
 		}
 		return instance;
 	}

--- a/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
@@ -35,14 +35,9 @@ public class WdmConfig {
 		conf = ConfigFactory.load();
 	}
 
-	public static WdmConfig getInstance() {
+	public static synchronized WdmConfig getInstance() {
 		if (instance == null) {
-			synchronized(WdmConfig.class) {
-				if (instance == null) {
-					instance = new WdmConfig();
-				}
-			}
-			
+			instance = new WdmConfig();
 		}
 		return instance;
 	}


### PR DESCRIPTION
Changed double-lock lazy initialisation to lock the whole getInstance method. Could have done using volatile in the instance field.