### PR TITLE
Add marionette driver support

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/DriverVersion.java
+++ b/src/main/java/io/github/bonigarcia/wdm/DriverVersion.java
@@ -22,6 +22,6 @@ package io.github.bonigarcia.wdm;
  */
 public enum DriverVersion {
 
-	LATEST, NOT_SPECIFIED;
+	LATEST, NOT_SPECIFIED
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/MarionetteDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/MarionetteDriverManager.java
@@ -1,0 +1,116 @@
+/*
+ * (C) Copyright 2015 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public License
+ * (LGPL) version 2.1 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+package io.github.bonigarcia.wdm;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.internal.LinkedTreeMap;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manager for Opera.
+ *
+ * @author Boni Garcia (boni.gg@gmail.com)
+ * @since 1.3.2
+ */
+public class MarionetteDriverManager extends BrowserManager{
+
+    private static MarionetteDriverManager instance;
+
+    protected MarionetteDriverManager() {
+    }
+
+    public static synchronized MarionetteDriverManager getInstance() {
+        if (instance == null) {
+            instance = new MarionetteDriverManager();
+        }
+        return instance;
+    }
+
+    @Override
+    public List<URL> getDrivers() throws IOException {
+        URL driverUrl = getDriverUrl();
+        String driverVersion = getDriverVersion();
+
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(driverUrl.openStream()));
+
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        Gson gson = gsonBuilder.create();
+        GitHubApi[] releaseArray = gson.fromJson(reader, GitHubApi[].class);
+        GitHubApi release;
+        if (driverVersion == null || driverVersion.isEmpty() || driverVersion
+                .equalsIgnoreCase(DriverVersion.LATEST.name())) {
+            log.debug("Connecting to {} to check latest MarionetteDriver release",
+                    driverUrl);
+            driverVersion = releaseArray[0].getName();
+            log.debug("Latest driver version: {}", driverVersion);
+            release = releaseArray[0];
+        } else {
+            release = getVersion(releaseArray, driverVersion);
+        }
+        if (release == null) {
+            throw new RuntimeException("Version " + driverVersion
+                    + " is not available for MarionetteDriver");
+        }
+
+        List<LinkedTreeMap<String, Object>> assets = release.getAssets();
+        List<URL> urls = new ArrayList<>();
+        for (LinkedTreeMap<String, Object> asset : assets) {
+            urls.add(new URL(asset.get("browser_download_url").toString()));
+        }
+
+        reader.close();
+        return urls;
+    }
+
+    private GitHubApi getVersion(GitHubApi[] releaseArray, String version) {
+        GitHubApi out = null;
+        for (GitHubApi release : releaseArray) {
+            if (release.getName().equalsIgnoreCase(version)) {
+                out = release;
+                break;
+            }
+        }
+        return out;
+    }
+
+    @Override
+    protected String getExportParameter() {
+        return WdmConfig.getString("wdm.marionetteDriverExport");
+    }
+
+    @Override
+    protected String getDriverVersion() {
+        return WdmConfig.getString("wdm.marionetteDriverVersion");
+    }
+
+    @Override
+    protected String getDriverName() {
+        return "wires";
+    }
+
+    @Override
+    protected URL getDriverUrl() throws MalformedURLException {
+        return WdmConfig.getUrl("wdm.marionetteDriverUrl");
+    }
+}

--- a/src/main/java/io/github/bonigarcia/wdm/MarionetteDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/MarionetteDriverManager.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Manager for Opera.
+ * Manager for Marionette.
  *
  * @author Boni Garcia (boni.gg@gmail.com)
  * @since 1.3.2

--- a/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
@@ -60,7 +60,7 @@ public class OperaDriverManager extends BrowserManager {
 		GitHubApi release;
 		if (driverVersion == null || driverVersion.isEmpty() || driverVersion
 				.equalsIgnoreCase(DriverVersion.LATEST.name())) {
-			log.debug("Connecting to {} to check lastest OperaDriver release",
+			log.debug("Connecting to {} to check latest OperaDriver release",
 					driverUrl);
 			driverVersion = releaseArray[0].getName();
 			log.debug("Latest driver version: {}", driverVersion);
@@ -74,7 +74,7 @@ public class OperaDriverManager extends BrowserManager {
 		}
 
 		List<LinkedTreeMap<String, Object>> assets = release.getAssets();
-		List<URL> urls = new ArrayList<URL>();
+		List<URL> urls = new ArrayList<>();
 		for (LinkedTreeMap<String, Object> asset : assets) {
 			urls.add(new URL(asset.get("browser_download_url").toString()));
 		}

--- a/src/main/java/io/github/bonigarcia/wdm/OperativeSystem.java
+++ b/src/main/java/io/github/bonigarcia/wdm/OperativeSystem.java
@@ -21,5 +21,5 @@ package io.github.bonigarcia.wdm;
  * @since 1.0.0
  */
 public enum OperativeSystem {
-	win, linux, mac;
+	win, linux, mac
 }

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -58,6 +58,9 @@ public class WebDriverManager extends BrowserManager {
 			} else if (webDriverClass.equals(PhantomJSDriver.class)) {
 				browserManagerClass = PhantomJsDriverManager.class;
 
+			} else if (webDriverClass.equals(MarionetteDriverManager.class)) {
+				browserManagerClass = MarionetteDriverManager.class;
+
 			} else {
 				browserManagerClass = VoidDriverManager.class;
 			}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,7 @@ wdm.edgeVersion=LATEST
 wdm.phantomjsDriverUrl=https://bitbucket.org/ariya/phantomjs/downloads/
 wdm.phantomjsDriverExport=phantomjs.binary.path
 wdm.phantomjsDriverVersion=LATEST
+
+wdm.marionetteDriverUrl=https://api.github.com/repos/jgraham/wires/releases
+wdm.marionetteDriverExport=webdriver.gecko.driver
+wdm.marionetteDriverVersion=LATEST

--- a/src/test/java/io/github/bonigarcia/wdm/test/MarionetteTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/MarionetteTest.java
@@ -24,7 +24,7 @@ import org.openqa.selenium.firefox.MarionetteDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 /**
- * Test with Opera browser.
+ * Test with Marionette browser.
  *
  * @author Boni Garcia (boni.gg@gmail.com)
  * @since 1.3.2
@@ -40,7 +40,7 @@ public class MarionetteTest extends ManagerTest{
     public void setupTest() {
         DesiredCapabilities capabilities = DesiredCapabilities.firefox();
         capabilities.setCapability("marionette", true);
-        // This capability set need for dev\nightly(version 45+)firefox because this driver is target on it
+        // This capability set need for beta\dev\nightly(version 45+) firefox because this driver is target on it
         if (SystemUtils.IS_OS_LINUX) {
             capabilities.setCapability("binary", "/usr/bin/firefox");
         } else if (SystemUtils.IS_OS_WINDOWS) {

--- a/src/test/java/io/github/bonigarcia/wdm/test/MarionetteTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/MarionetteTest.java
@@ -1,0 +1,65 @@
+/*
+ * (C) Copyright 2015 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public License
+ * (LGPL) version 2.1 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+package io.github.bonigarcia.wdm.test;
+
+import io.github.bonigarcia.wdm.MarionetteDriverManager;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openqa.selenium.firefox.MarionetteDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+/**
+ * Test with Opera browser.
+ *
+ * @author Boni Garcia (boni.gg@gmail.com)
+ * @since 1.3.2
+ */
+public class MarionetteTest extends ManagerTest{
+
+    @BeforeClass
+    public static void setupClass() {
+        MarionetteDriverManager.getInstance().setup();
+    }
+
+    @Before
+    public void setupTest() {
+        DesiredCapabilities capabilities = DesiredCapabilities.firefox();
+        capabilities.setCapability("marionette", true);
+        // This capability set need for dev\nightly(version 45+)firefox because this driver is target on it
+        if (SystemUtils.IS_OS_LINUX) {
+            capabilities.setCapability("binary", "/usr/bin/firefox");
+        } else if (SystemUtils.IS_OS_WINDOWS) {
+            capabilities.setCapability("binary", "C:\\Program Files\\Mozilla Firefox\\firefox.exe");
+        } else if (SystemUtils.IS_OS_MAC_OSX) {
+            capabilities.setCapability("binary", "/Applications/Firefox.app");
+        }
+        driver = new MarionetteDriver(capabilities);
+    }
+
+    @After
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    public void testMarionette() {
+        browseWikipedia();
+    }
+}


### PR DESCRIPTION
Add support for new firefox webdriver.
[Marionette](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette)