### PR TITLE
Use 'tag_name' in addition to 'name' to determine correct gecko driver to download

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/GitHubApi.java
+++ b/src/main/java/io/github/bonigarcia/wdm/GitHubApi.java
@@ -29,6 +29,7 @@ import com.google.gson.internal.LinkedTreeMap;
 public class GitHubApi {
 
 	private String name;
+	private String tag_name;
 	private List<LinkedTreeMap<String, Object>> assets;
 
 	public GitHubApi() {
@@ -40,6 +41,14 @@ public class GitHubApi {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public String getTagName() {
+		return tag_name;
+	}
+
+	public void setTagName(String tagName) {
+		this.tag_name = tagName;
 	}
 
 	public List<LinkedTreeMap<String, Object>> getAssets() {

--- a/src/main/java/io/github/bonigarcia/wdm/MarionetteDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/MarionetteDriverManager.java
@@ -83,8 +83,8 @@ public class MarionetteDriverManager extends BrowserManager {
 	private GitHubApi getVersion(GitHubApi[] releaseArray, String version) {
 		GitHubApi out = null;
 		for (GitHubApi release : releaseArray) {
-			if (release.getName() != null
-					&& release.getName().contains(version)) {
+			if ((release.getName() != null && release.getName().contains(version))
+					|| (release.getTagName() != null && release.getTagName().contains(version))) {
 				out = release;
 				break;
 			}


### PR DESCRIPTION
The JSON contents of `https://api.github.com/repos/mozilla/geckodriver/releases`, used to determine the version of the gecko driver to download have not contain a value for the `name` property for the last two releases (v0.9.0 and v0.10.0) this means that the gecko driver is not downloaded. This is an issue when using selenium against Firefox 48 which requires geckodriver v0.10.0.

This change will additionally check the `tag_name` property if matching the `name` property fails.

```
[
  {
    "url": "https://api.github.com/repos/mozilla/geckodriver/releases/3798083",
    "assets_url": "https://api.github.com/repos/mozilla/geckodriver/releases/3798083/assets",
    "upload_url": "https://uploads.github.com/repos/mozilla/geckodriver/releases/3798083/assets{?name,label}",
    "html_url": "https://github.com/mozilla/geckodriver/releases/tag/v0.10.0",
    "id": 3798083,
    "tag_name": "v0.10.0",
    "target_commitish": "master",
    "name": "",
    "draft": false,
    ...
```