### PR TITLE
add travis ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: java
+sudo: true
+dist: trusty
+
+before_install:
+    # Add repos
+    - sudo apt-add-repository "deb http://deb.opera.com/opera-stable/ stable non-free"
+    - sudo apt-add-repository "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+    # Remove "deb-src" repos added from apt-add-repository, because it doesn't exist online
+    - sudo sed -i s/deb-src.*opera.*//g /etc/apt/sources.list
+    - sudo sed -i s/deb-src.*google.*//g /etc/apt/sources.list
+    # Add apt-keys for checking the packages
+    - wget -O - http://deb.opera.com/archive.key | sudo apt-key add -
+    - wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+    # Mke sure
+    - sudo apt-get update -qq
+    # Install the browsers
+    - sudo apt-get install -y opera-stable google-chrome-stable
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start


### PR DESCRIPTION
Adds support for travis CI server. All tests except the opera test are green. I don't know why yet...
The tests are a bit shaky due to the 403 github  API / phantomjs mirror issue.
Support for a different download location would be good to fix that that problem. See #56 

Find a build log here: https://travis-ci.org/hennr/webdrivermanager/builds/156056755

Note: Make sure to enable travis for this repo before merging to get a travis run straigt away.