### PR TITLE
skip operaTest on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,4 @@ before_install:
     - sleep 3 # give xvfb some time to start
 
 install:
-    # operachromiumdriver does not work with xvfb, see: https://github.com/operasoftware/operachromiumdriver/issues/26
-    - mvn -Dheadless=true clean verify
+    - mvn -DheadlessEnvironment=true clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: true
 dist: trusty
 
-before_install:
+install:
     # Add repos
     - sudo apt-add-repository "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
     # Remove "deb-src" repos added from apt-add-repository, because it doesn't exist online
@@ -13,10 +13,12 @@ before_install:
     - sudo apt-get update -qq
     # Install the browsers
     - sudo apt-get install -y google-chrome-stable
+
+before_script:
     # start xvfb
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
     - sleep 3 # give xvfb some time to start
 
-install:
-    - mvn -DheadlessEnvironment=true clean verify
+script:
+    - mvn -DheadlessEnvironment=true verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,20 @@ dist: trusty
 
 before_install:
     # Add repos
-    - sudo apt-add-repository "deb http://deb.opera.com/opera-stable/ stable non-free"
     - sudo apt-add-repository "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
     # Remove "deb-src" repos added from apt-add-repository, because it doesn't exist online
-    - sudo sed -i s/deb-src.*opera.*//g /etc/apt/sources.list
     - sudo sed -i s/deb-src.*google.*//g /etc/apt/sources.list
     # Add apt-keys for checking the packages
-    - wget -O - http://deb.opera.com/archive.key | sudo apt-key add -
     - wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     # Mke sure
     - sudo apt-get update -qq
     # Install the browsers
-    - sudo apt-get install -y opera-stable google-chrome-stable
+    - sudo apt-get install -y google-chrome-stable
+    # start xvfb
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
+    - sleep 3 # give xvfb some time to start
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+install:
+    # operachromiumdriver does not work with xvfb, see: https://github.com/operasoftware/operachromiumdriver/issues/26
+    - mvn -Dheadless=true clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>io.github.bonigarcia</groupId>
 	<artifactId>webdrivermanager</artifactId>
 	<version>1.4.9-SNAPSHOT</version>

--- a/src/test/java/io/github/bonigarcia/wdm/test/OperaTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/OperaTest.java
@@ -36,11 +36,13 @@ import io.github.bonigarcia.wdm.base.BaseBrowserTst;
  */
 public class OperaTest extends BaseBrowserTst {
 
-	static boolean headlessMode = "true".equals(System.getProperty("headless"));
+	// opera does not work with xvfb which is used on the ci server
+	// see: https://github.com/operasoftware/operachromiumdriver/issues/26
+	private static boolean ignoreTestInHeadlessEnvironment = "true".equals(System.getProperty("headlessEnvironment"));
 
 	@BeforeClass
 	public static void setupClass() {
-		if (headlessMode) {
+		if (ignoreTestInHeadlessEnvironment) {
 			validOS = false;
 			assumeTrue(false);
 		}
@@ -49,7 +51,7 @@ public class OperaTest extends BaseBrowserTst {
 
 	@Before
 	public void setupTest() {
-        if (headlessMode) {
+        if (ignoreTestInHeadlessEnvironment) {
             return;
         }
 		DesiredCapabilities capabilities = DesiredCapabilities.operaBlink();

--- a/src/test/java/io/github/bonigarcia/wdm/test/OperaTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/OperaTest.java
@@ -15,6 +15,7 @@
 package io.github.bonigarcia.wdm.test;
 
 import static org.apache.commons.lang3.SystemUtils.IS_OS_LINUX;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 
@@ -35,8 +36,14 @@ import io.github.bonigarcia.wdm.base.BaseBrowserTst;
  */
 public class OperaTest extends BaseBrowserTst {
 
+	static boolean headlessMode = "true".equals(System.getProperty("headless"));
+
 	@BeforeClass
 	public static void setupClass() {
+		if (headlessMode) {
+			validOS = false;
+			assumeTrue(false);
+		}
 		OperaDriverManager.getInstance().setup();
 	}
 

--- a/src/test/java/io/github/bonigarcia/wdm/test/OperaTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/OperaTest.java
@@ -49,6 +49,9 @@ public class OperaTest extends BaseBrowserTst {
 
 	@Before
 	public void setupTest() {
+        if (headlessMode) {
+            return;
+        }
 		DesiredCapabilities capabilities = DesiredCapabilities.operaBlink();
 		if (IS_OS_LINUX) {
 			OperaOptions options = new OperaOptions();


### PR DESCRIPTION
the operadriver does not support xvfb as far as I can tell.
I openend [an issue](https://github.com/operasoftware/operachromiumdriver/issues/26) but chances are low that it will get fixed.

Ignoring the opera test on travis seems the best solution for us at the moment.