### PR TITLE
Custom property file name

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
@@ -31,7 +31,7 @@ public class WdmConfig {
 	private static WdmConfig instance;
 	private Config conf;
 
-	public static final String propertyFileName = System.getProperty("wdm.prop.file","application.properties");
+	public static final String propertyFileName = System.getProperty("wdm.prop.filename","application.properties");
 
 	protected WdmConfig() {
 		conf = ConfigFactory.load(propertyFileName);

--- a/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
@@ -31,8 +31,10 @@ public class WdmConfig {
 	private static WdmConfig instance;
 	private Config conf;
 
+	public static final String propertyFileName = System.getProperty("wdm.prop.file","application.properties");
+
 	protected WdmConfig() {
-		conf = ConfigFactory.load();
+		conf = ConfigFactory.load(propertyFileName);
 	}
 
 	public static synchronized WdmConfig getInstance() {


### PR DESCRIPTION
This PR will add ability for user to set property file name for WDM.

Example:
*test.properties*

It can be done by System.setProperty("wdm.prop.file","test") or call WdmConfig.propertyFileName="test"