### PR TITLE
Allow running in separate classloader

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WdmConfig.java
@@ -32,8 +32,8 @@ public class WdmConfig {
 	private Config conf;
 
 	protected WdmConfig() {
-		conf = ConfigFactory.load(System.getProperty("wdm.properties",
-				"webdrivermanager.properties"));
+		conf = ConfigFactory.load(WdmConfig.class.getClassLoader(),
+				System.getProperty("wdm.properties","webdrivermanager.properties"));
 	}
 
 	public static synchronized WdmConfig getInstance() {


### PR DESCRIPTION
If webdrivermanager is used from within a separate classloader it can't find its webdrivermanager.properties file and results in the following exception:

`com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'wdm'`

This changes ensures that the correct classloader is used when attempting to load the config.