### PR TITLE
Support proxy server that needs an authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 		<jsoup.version>1.10.2</jsoup.version>
 		<guava.version>21.0</guava.version>
 		<commons-codec.version>1.10</commons-codec.version>
+		<httpclient.version>4.5.3</httpclient.version>
 
 		<junit.version>4.12</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
@@ -98,6 +99,11 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>${commons-lang3.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${httpclient.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.rauschig</groupId>

--- a/src/main/java/io/github/bonigarcia/wdm/BrowserManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/BrowserManager.java
@@ -27,18 +27,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -68,12 +65,12 @@ public abstract class BrowserManager {
 
 	protected static final Logger log = LoggerFactory
 			.getLogger(BrowserManager.class);
-	protected static final String TAOBAO_MIRROR = "npm.taobao.org";
-	protected static final String SEPARATOR = "/";
+	public static final String TAOBAO_MIRROR = "npm.taobao.org";
+	public static final String SEPARATOR = "/";
 
-	private static final Architecture DEFAULT_ARCH = Architecture
+	public static final Architecture DEFAULT_ARCH = Architecture
 			.valueOf("x" + System.getProperty("sun.arch.data.model"));
-	private static final String MY_OS_NAME = getOsName();
+	public static final String MY_OS_NAME = getOsName();
 
 	protected abstract List<URL> getDrivers() throws Exception;
 
@@ -102,6 +99,21 @@ public abstract class BrowserManager {
 	protected URL driverUrl;
 
 	protected String proxy;
+
+	/**
+	 * @since 1.6.2
+	 */
+	protected String proxyUser;
+
+	/**
+	 * @since 1.6.2
+	 */
+	protected String proxyPass;
+
+	/**
+	 * @since 1.6.2
+	 */
+	protected WdmHttpClient httpClient;
 
 	protected String getDriverVersion() {
 		return version == null ? WdmConfig.getString(getDriverVersionKey())
@@ -141,8 +153,13 @@ public abstract class BrowserManager {
 	}
 
 	protected void manage(Architecture arch, String version) {
-		try {
-			Downloader downloader = new Downloader(this);
+
+		this.httpClient = new WdmHttpClient.Builder()
+			.proxy(proxy).proxyUser(proxyUser).proxyPass(proxyPass).build();
+
+		try (WdmHttpClient httpClient = this.httpClient) {
+
+			Downloader downloader = new Downloader(this, httpClient);
 			if (forceDownload) {
 				downloader.forceDownload();
 			}
@@ -299,7 +316,7 @@ public abstract class BrowserManager {
 				driverInCache = f.toString();
 
 				// Exception for phantomjs
-				boolean architecture = driverName.equals("phantomjs")
+				boolean architecture = !shouldCheckArchitecture(driverName)
 						|| driverInCache.contains(arch.toString());
 				log.trace("Checking {}", driverInCache);
 
@@ -331,19 +348,24 @@ public abstract class BrowserManager {
 				: file.canExecute();
 	}
 
+	/**
+	 * @since 1.6.2
+	 */
+	protected boolean shouldCheckArchitecture(String driverName) {
+		return true;
+	}
+
 	protected boolean isNetAvailable() {
 		try {
-			URL url = getDriverUrl();
-			Proxy proxy = createProxy();
-			URLConnection conn = proxy != null ? url.openConnection(proxy)
-					: url.openConnection();
-
-			conn.connect();
-			return true;
+			if (!httpClient.isValid(getDriverUrl())) {
+				log.warn("Page no available. Forcing the use of cache");
+				return false;
+			}
 		} catch (IOException e) {
 			log.warn("Network not available. Forcing the use of cache");
 			return false;
 		}
+		return true;
 	}
 
 	protected List<URL> filter(List<URL> list, Architecture arch) {
@@ -564,26 +586,27 @@ public abstract class BrowserManager {
 
 		String driverStr = driverUrl.toString();
 		String driverUrlContent = driverUrl.getPath();
+		int timeout = (int) TimeUnit.SECONDS.toMillis(WdmConfig.getInt("wdm.timeout"));
 
-		org.jsoup.nodes.Document doc = Jsoup.connect(driverStr)
-				.timeout((int) TimeUnit.SECONDS
-						.toMillis(WdmConfig.getInt("wdm.timeout")))
-				.proxy(createProxy()).get();
-		Iterator<org.jsoup.nodes.Element> iterator = doc.select("a").iterator();
-		List<URL> urlList = new ArrayList<>();
+		WdmHttpClient.Response response = httpClient.execute(new WdmHttpClient.Get(driverStr, timeout));
+		try (InputStream in = response.getContent()) {
+			org.jsoup.nodes.Document doc = Jsoup.parse(in, null, "");
+			Iterator<org.jsoup.nodes.Element> iterator = doc.select("a").iterator();
+			List<URL> urlList = new ArrayList<>();
 
-		while (iterator.hasNext()) {
-			String link = iterator.next().attr("href");
-			if (link.contains("mirror") && link.endsWith(SEPARATOR)) {
-				urlList.addAll(getDriversFromMirror(new URL(
-						driverStr + link.replace(driverUrlContent, ""))));
-			} else if (link.startsWith(driverUrlContent)
-					&& !link.contains("icons")) {
-				urlList.add(new URL(
-						driverStr + link.replace(driverUrlContent, "")));
+			while (iterator.hasNext()) {
+				String link = iterator.next().attr("href");
+				if (link.contains("mirror") && link.endsWith(SEPARATOR)) {
+					urlList.addAll(getDriversFromMirror(new URL(
+							driverStr + link.replace(driverUrlContent, ""))));
+				} else if (link.startsWith(driverUrlContent)
+						&& !link.contains("icons")) {
+					urlList.add(new URL(
+							driverStr + link.replace(driverUrlContent, "")));
+				}
 			}
+			return urlList;
 		}
-		return urlList;
 	}
 
 	protected List<URL> getDriversFromXml(URL driverUrl,
@@ -596,24 +619,21 @@ public abstract class BrowserManager {
 		int maxRetries = WdmConfig.getInt("wdm.seekErrorRetries");
 		do {
 			try {
-				Proxy proxy = createProxy();
-				URLConnection conn = proxy != null
-						? driverUrl.openConnection(proxy)
-						: driverUrl.openConnection();
-				BufferedReader reader = new BufferedReader(
-						new InputStreamReader(conn.getInputStream()));
-				Document xml = loadXML(reader);
+				WdmHttpClient.Response response = httpClient.execute(new WdmHttpClient.Get(driverUrl));
+				try (BufferedReader reader = new BufferedReader(
+						new InputStreamReader(response.getContent()))) {
+					Document xml = loadXML(reader);
 
-				XPath xPath = XPathFactory.newInstance().newXPath();
-				NodeList nodes = (NodeList) xPath.evaluate("//Contents/Key",
+					XPath xPath = XPathFactory.newInstance().newXPath();
+					NodeList nodes = (NodeList) xPath.evaluate("//Contents/Key",
 						xml.getDocumentElement(), XPathConstants.NODESET);
 
-				for (int i = 0; i < nodes.getLength(); ++i) {
-					Element e = (Element) nodes.item(i);
-					String version = e.getChildNodes().item(0).getNodeValue();
-					urls.add(new URL(driverUrl + version));
+					for (int i = 0; i < nodes.getLength(); ++i) {
+						Element e = (Element) nodes.item(i);
+						String version = e.getChildNodes().item(0).getNodeValue();
+						urls.add(new URL(driverUrl + version));
+					}
 				}
-				reader.close();
 				break;
 			} catch (Throwable e) {
 				log.warn("[{}/{}] Exception reading {} to seek {}: {} {}",
@@ -656,12 +676,10 @@ public abstract class BrowserManager {
 	}
 
 	protected InputStream openGitHubConnection(URL driverUrl)
-			throws IOException {
-		Proxy proxy = createProxy();
-		URLConnection conn = proxy != null ? driverUrl.openConnection(proxy)
-				: driverUrl.openConnection();
-		conn.setRequestProperty("User-Agent", "Mozilla/5.0");
-		conn.addRequestProperty("Connection", "keep-alive");
+		throws IOException {
+		WdmHttpClient.Get get = new WdmHttpClient.Get(driverUrl)
+			.addHeader("User-Agent", "Mozilla/5.0")
+			.addHeader("Connection", "keep-alive");
 
 		String gitHubTokenName = WdmConfig.getString("wdm.gitHubTokenName");
 		String gitHubTokenSecret = WdmConfig.getString("wdm.gitHubTokenSecret");
@@ -670,36 +688,18 @@ public abstract class BrowserManager {
 			String userpass = gitHubTokenName + ":" + gitHubTokenSecret;
 			String basicAuth = "Basic "
 					+ new String(new Base64().encode(userpass.getBytes()));
-			conn.setRequestProperty("Authorization", basicAuth);
+			get.addHeader("Authorization", basicAuth);
 		}
-		conn.connect();
 
-		return conn.getInputStream();
+		return httpClient.execute(get).getContent();
 	}
 
+	/**
+	 * @deprecated Since 1.6.2. This method remain to keep a backward compatibility(gh-118).
+	 */
+	@Deprecated
 	protected Proxy createProxy() {
-		String proxyInput = isNullOrEmpty(proxy) ? System.getenv("HTTPS_PROXY")
-				: proxy;
-		if (isNullOrEmpty(proxyInput)) {
-			return null;
-		}
-		String proxyString = proxyInput.replace("http://", "")
-				.replace("https://", "");
-		StringTokenizer st = new StringTokenizer(proxyString, ":");
-		String host = st.hasMoreTokens() ? st.nextToken() : "";
-		String portString = st.hasMoreTokens() ? st.nextToken() : "80";
-
-		try {
-			int port = Integer.parseInt(portString);
-			log.info("Using proxy {} (host={}, port={})", proxyInput, host,
-					port);
-
-			return new Proxy(Proxy.Type.HTTP,
-					new InetSocketAddress(host, port));
-		} catch (NumberFormatException e) {
-			log.error("Number format exception parsing {}", portString, e);
-			return null;
-		}
+		return httpClient.createProxy(proxy);
 	}
 
 	// *************************************
@@ -802,6 +802,22 @@ public abstract class BrowserManager {
 
 	public BrowserManager proxy(String proxy) {
 		this.proxy = proxy;
+		return this;
+	}
+
+	/**
+	 * @since 1.6.2
+	 */
+	public BrowserManager proxyUser(String proxyUser) {
+		this.proxyUser = proxyUser;
+		return this;
+	}
+
+	/**
+	 * @since 1.6.2
+	 */
+	public BrowserManager proxyPass(String proxyPass) {
+		this.proxyPass = proxyPass;
 		return this;
 	}
 

--- a/src/main/java/io/github/bonigarcia/wdm/FirefoxDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/FirefoxDriverManager.java
@@ -56,30 +56,30 @@ public class FirefoxDriverManager extends BrowserManager {
 
 			String driverVersion = versionToDownload;
 
-			BufferedReader reader = new BufferedReader(
-					new InputStreamReader(openGitHubConnection(driverUrl)));
+			try (BufferedReader reader = new BufferedReader(
+					new InputStreamReader(openGitHubConnection(driverUrl)))) {
 
-			GsonBuilder gsonBuilder = new GsonBuilder();
-			Gson gson = gsonBuilder.create();
-			GitHubApi[] releaseArray = gson.fromJson(reader, GitHubApi[].class);
+				GsonBuilder gsonBuilder = new GsonBuilder();
+				Gson gson = gsonBuilder.create();
+				GitHubApi[] releaseArray = gson.fromJson(reader, GitHubApi[].class);
 
-			if (driverVersion != null) {
-				releaseArray = new GitHubApi[] {
-						getVersion(releaseArray, driverVersion) };
-			}
+				if (driverVersion != null) {
+					releaseArray = new GitHubApi[]{
+						getVersion(releaseArray, driverVersion)};
+				}
 
-			urls = new ArrayList<>();
-			for (GitHubApi release : releaseArray) {
-				if (release != null) {
-					List<LinkedTreeMap<String, Object>> assets = release
+				urls = new ArrayList<>();
+				for (GitHubApi release : releaseArray) {
+					if (release != null) {
+						List<LinkedTreeMap<String, Object>> assets = release
 							.getAssets();
-					for (LinkedTreeMap<String, Object> asset : assets) {
-						urls.add(new URL(
+						for (LinkedTreeMap<String, Object> asset : assets) {
+							urls.add(new URL(
 								asset.get("browser_download_url").toString()));
+						}
 					}
 				}
 			}
-			reader.close();
 		}
 		return urls;
 	}
@@ -156,4 +156,11 @@ public class FirefoxDriverManager extends BrowserManager {
 		return instance;
 	}
 
+	/**
+	 * @since 1.6.2
+	 */
+	@Override
+	protected boolean shouldCheckArchitecture(String driverName) {
+		return !MY_OS_NAME.contains(OperativeSystem.mac.name());
+	}
 }

--- a/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
@@ -53,29 +53,29 @@ public class OperaDriverManager extends BrowserManager {
 		} else {
 			String driverVersion = versionToDownload;
 
-			BufferedReader reader = new BufferedReader(
-					new InputStreamReader(openGitHubConnection(driverUrl)));
+			try (BufferedReader reader = new BufferedReader(
+					new InputStreamReader(openGitHubConnection(driverUrl)))) {
 
-			GsonBuilder gsonBuilder = new GsonBuilder();
-			Gson gson = gsonBuilder.create();
-			GitHubApi[] releaseArray = gson.fromJson(reader, GitHubApi[].class);
-			if (driverVersion != null) {
-				releaseArray = new GitHubApi[] {
-						getVersion(releaseArray, driverVersion) };
-			}
+				GsonBuilder gsonBuilder = new GsonBuilder();
+				Gson gson = gsonBuilder.create();
+				GitHubApi[] releaseArray = gson.fromJson(reader, GitHubApi[].class);
+				if (driverVersion != null) {
+					releaseArray = new GitHubApi[]{
+						getVersion(releaseArray, driverVersion)};
+				}
 
-			urls = new ArrayList<>();
-			for (GitHubApi release : releaseArray) {
-				if (release != null) {
-					List<LinkedTreeMap<String, Object>> assets = release
+				urls = new ArrayList<>();
+				for (GitHubApi release : releaseArray) {
+					if (release != null) {
+						List<LinkedTreeMap<String, Object>> assets = release
 							.getAssets();
-					for (LinkedTreeMap<String, Object> asset : assets) {
-						urls.add(new URL(
+						for (LinkedTreeMap<String, Object> asset : assets) {
+							urls.add(new URL(
 								asset.get("browser_download_url").toString()));
+						}
 					}
 				}
 			}
-			reader.close();
 		}
 		return urls;
 	}

--- a/src/main/java/io/github/bonigarcia/wdm/PhantomJsDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/PhantomJsDriverManager.java
@@ -133,4 +133,12 @@ public class PhantomJsDriverManager extends BrowserManager {
 		}
 		return instance;
 	}
+
+	/**
+	 * @since 1.6.2
+	 */
+	@Override
+	protected boolean shouldCheckArchitecture(String driverName) {
+		return false;
+	}
 }

--- a/src/main/java/io/github/bonigarcia/wdm/WdmHttpClient.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WdmHttpClient.java
@@ -1,0 +1,256 @@
+/*
+ * (C) Copyright 2015 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public License
+ * (LGPL) version 2.1 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+package io.github.bonigarcia.wdm;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.StringTokenizer;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Http Client for WebDriverManager.
+ *
+ * @author Kazuki Shimizu
+ * @since 1.6.2
+ */
+public class WdmHttpClient implements Closeable {
+
+	protected static final Logger log = LoggerFactory.getLogger(BrowserManager.class);
+
+	private final CloseableHttpClient httpClient;
+
+	private WdmHttpClient(String proxyUrl, String proxyUser, String proxyPass) {
+		HttpHost proxyHost = createProxyHttpHost(proxyUrl);
+		HttpClientBuilder builder = HttpClientBuilder.create();
+		if (proxyHost != null) {
+			builder.setProxy(proxyHost);
+			BasicCredentialsProvider credentialsProvider = createBasicCredentialsProvider(proxyUrl, proxyUser, proxyPass,
+					proxyHost);
+			builder.setDefaultCredentialsProvider(credentialsProvider);
+		}
+		this.httpClient = builder.build();
+	}
+
+	Proxy createProxy(String proxyUrl) {
+		URL url = determineProxyUrl(proxyUrl);
+		if (url == null) {
+			return null;
+		}
+		String proxyHost = url.getHost();
+		int proxyPort = url.getPort() == -1 ? 80 : url.getPort();
+		return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+	}
+
+	public Response execute(Method method) throws IOException {
+		HttpResponse response = httpClient.execute(method.toHttpUriRequest());
+		if (response.getStatusLine().getStatusCode() >= HttpStatus.SC_BAD_REQUEST) {
+			throw new RuntimeException("A response error is detected. " + response.getStatusLine());
+		}
+		return new Response(response);
+	}
+
+	public boolean isValid(URL url) throws IOException {
+		HttpResponse response = httpClient.execute(new WdmHttpClient.Options(url).toHttpUriRequest());
+		if (response.getStatusLine().getStatusCode() >= HttpStatus.SC_BAD_REQUEST) {
+			if (log.isDebugEnabled()) {
+				log.debug("A response error is detected. {}", response.getStatusLine());
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private URL determineProxyUrl(String proxy) {
+		String proxyInput = isNullOrEmpty(proxy) ? System.getenv("HTTPS_PROXY") : proxy;
+		if (isNullOrEmpty(proxyInput)) {
+			return null;
+		}
+		try {
+			return new URL(proxyInput.matches("^http[s]?://.*$") ? proxyInput : "http://" + proxyInput);
+		} catch (MalformedURLException e) {
+			log.error("Invalid proxy url {}", proxyInput, e);
+			return null;
+		}
+	}
+
+	private final HttpHost createProxyHttpHost(String proxyUrl) {
+		Proxy proxy = createProxy(proxyUrl);
+		if (proxy == null || proxy.address() == null) {
+			return null;
+		}
+		if (!(proxy.address() instanceof InetSocketAddress)) {
+			throw new RuntimeException(
+					"Detect an unsupported subclass of SocketAddress. Please use the InetSocketAddress or subclass. Actual:"
+							+ proxy.address().getClass());
+		}
+		InetSocketAddress proxyAddress = (InetSocketAddress) proxy.address();
+		return new HttpHost(proxyAddress.getHostName(), proxyAddress.getPort());
+	}
+
+	private final BasicCredentialsProvider createBasicCredentialsProvider(String proxy, String proxyUser,
+			String proxyPass, HttpHost proxyHost) {
+		URL proxyUrl = determineProxyUrl(proxy);
+		if (proxyUrl == null) {
+			return null;
+		}
+		try {
+			String username = null;
+			String password = null;
+
+			// apply env value
+			String userInfo = proxyUrl.getUserInfo();
+			if (userInfo != null) {
+				StringTokenizer st = new StringTokenizer(userInfo, ":");
+				username = st.hasMoreTokens() ? URLDecoder.decode(st.nextToken(), StandardCharsets.UTF_8.name()) : null;
+				password = st.hasMoreTokens() ? URLDecoder.decode(st.nextToken(), StandardCharsets.UTF_8.name()) : null;
+			}
+			String envProxyUser = System.getenv("HTTPS_PROXY_USER");
+			String envProxyPass = System.getenv("HTTPS_PROXY_PASS");
+			username = (envProxyUser != null) ? envProxyUser : username;
+			password = (envProxyPass != null) ? envProxyPass : password;
+
+			// apply option value
+			username = (proxyUser != null) ? proxyUser : username;
+			password = (proxyPass != null) ? proxyPass : password;
+
+			if (username == null) {
+				return null;
+			}
+
+			BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+			credentialsProvider.setCredentials(new AuthScope(proxyHost.getHostName(), proxyHost.getPort()),
+					new UsernamePasswordCredentials(username, password));
+			return credentialsProvider;
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException("Invalid encoding.", e);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.httpClient.close();
+	}
+
+	public static class Builder {
+
+		private String proxy;
+		private String proxyUser;
+		private String proxyPass;
+
+		public Builder proxy(String proxy) {
+			this.proxy = proxy;
+			return this;
+		}
+
+		public Builder proxyUser(String proxyUser) {
+			this.proxyUser = proxyUser;
+			return this;
+		}
+
+		public Builder proxyPass(String proxyPass) {
+			this.proxyPass = proxyPass;
+			return this;
+		}
+
+		public WdmHttpClient build() {
+			return new WdmHttpClient(this.proxy, this.proxyUser, this.proxyPass);
+		}
+
+	}
+
+	private interface Method {
+		HttpUriRequest toHttpUriRequest();
+	}
+
+	public final static class Get implements Method {
+		private final HttpGet get;
+		private final RequestConfig config;
+
+		public Get(URL url) {
+			this.get = new HttpGet(url.toString());
+			this.config = null;
+		}
+
+		public Get(String url, int socketTimeout) {
+			this.get = new HttpGet(url);
+			this.config = RequestConfig.custom().setSocketTimeout(socketTimeout).build();
+		}
+
+		public Get addHeader(String name, String value) {
+			this.get.addHeader(name, value);
+			return this;
+		}
+
+		@Override
+		public HttpUriRequest toHttpUriRequest() {
+			if (config != null) {
+				get.setConfig(config);
+			}
+			return this.get;
+		}
+
+	}
+
+	public final static class Options implements Method {
+		private final HttpOptions options;
+
+		public Options(URL url) {
+			this.options = new HttpOptions(url.toString());
+		}
+
+		@Override
+		public HttpUriRequest toHttpUriRequest() {
+			return this.options;
+		}
+	}
+
+	public final static class Response {
+		private final HttpResponse response;
+
+		public Response(HttpResponse response) {
+			this.response = response;
+		}
+
+		public InputStream getContent() throws IOException {
+			return this.response.getEntity().getContent();
+		}
+
+	}
+
+}

--- a/src/test/java/io/github/bonigarcia/wdm/base/BaseBrowserTst.java
+++ b/src/test/java/io/github/bonigarcia/wdm/base/BaseBrowserTst.java
@@ -28,7 +28,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  * @author Boni Garcia (boni.gg@gmail.com)
  * @since 1.4.1
  */
-public class BaseBrowserTst {
+public abstract class BaseBrowserTst {
 
 	protected static final int TIMEOUT = 30; // seconds
 

--- a/src/test/java/io/github/bonigarcia/wdm/base/BaseVersionTst.java
+++ b/src/test/java/io/github/bonigarcia/wdm/base/BaseVersionTst.java
@@ -38,7 +38,7 @@ import io.github.bonigarcia.wdm.BrowserManager;
  * @since 1.4.1
  */
 @RunWith(Parameterized.class)
-public class BaseVersionTst {
+public abstract class BaseVersionTst {
 
 	@Parameter
 	public Architecture architecture;

--- a/src/test/java/io/github/bonigarcia/wdm/test/CacheTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/CacheTest.java
@@ -19,10 +19,19 @@ import static io.github.bonigarcia.wdm.Architecture.x64;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 
+import io.github.bonigarcia.wdm.Architecture;
+import io.github.bonigarcia.wdm.BrowserManager;
+import io.github.bonigarcia.wdm.Downloader;
+import io.github.bonigarcia.wdm.OperativeSystem;
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -33,11 +42,6 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.opera.OperaDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
-
-import io.github.bonigarcia.wdm.Architecture;
-import io.github.bonigarcia.wdm.BrowserManager;
-import io.github.bonigarcia.wdm.Downloader;
-import io.github.bonigarcia.wdm.WebDriverManager;
 
 /**
  * Test for driver cache.
@@ -59,11 +63,17 @@ public class CacheTest {
 
 	@Parameters(name = "{index}: {0} {1} {2}")
 	public static Collection<Object[]> data() {
+		boolean isMac = BrowserManager.MY_OS_NAME.contains(OperativeSystem.mac.name());
 		return Arrays
-				.asList(new Object[][] { { ChromeDriver.class, "2.27", x32 },
+				.asList(new Object[][] { { ChromeDriver.class, "2.27", isMac ? x64 : x32 },
 						{ OperaDriver.class, "0.2.2", x64 },
 						{ PhantomJSDriver.class, "2.1.1", x64 },
 						{ FirefoxDriver.class, "0.14.0", x64 } });
+	}
+
+	@Before
+	public void deleteDownloadedFiles() throws IOException {
+		FileUtils.cleanDirectory(new File(new Downloader(null).getTargetPath()));
 	}
 
 	@Test

--- a/src/test/java/io/github/bonigarcia/wdm/test/PhantomJsFilterTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/PhantomJsFilterTest.java
@@ -14,12 +14,14 @@
  */
 package io.github.bonigarcia.wdm.test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WdmHttpClient;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,6 +51,9 @@ public class PhantomJsFilterTest {
 	@SuppressWarnings("unchecked")
 	public void setup() throws Exception {
 		phatomJsManager = PhantomJsDriverManager.getInstance();
+		Field field = BrowserManager.class.getDeclaredField("httpClient");
+		field.setAccessible(true);
+		field.set(phatomJsManager, new WdmHttpClient.Builder().build());
 
 		Method method = BrowserManager.class.getDeclaredMethod("getDrivers");
 		method.setAccessible(true);


### PR DESCRIPTION
I've fixed gh-118.

This PR contains following changes:

* Use the Apache Components HttpClient instead of URLHttpConnection provided by JDK
* Provide the wrapper class(`WdmHttpClient`) to hide the Apache HttpClient implementation
* Add options to specify user and password for connecting proxy server
* Deprecate the `BrowserManager#createProxy`. (This method remain to keep a backward compatibility in this version)
* Change protected constant to public constant on some constant
* Polish some logic
* Polish some test cases

Note that some test cases are failed. But these errors are failed on master branch. I Think these errors not related with this changes.

Please review this. 

Thanks.