### PR TITLE
Allow global configuration for GitHub API Token

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/BrowserManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/BrowserManager.java
@@ -691,7 +691,13 @@ public abstract class BrowserManager {
 				.addHeader("Connection", "keep-alive");
 
 		String gitHubTokenName = WdmConfig.getString("wdm.gitHubTokenName");
+		gitHubTokenName = isNullOrEmpty(gitHubTokenName) ?
+				System.getenv("WDM_GIT_HUB_TOKEN_NAME") : gitHubTokenName;
+
 		String gitHubTokenSecret = WdmConfig.getString("wdm.gitHubTokenSecret");
+		gitHubTokenSecret = isNullOrEmpty(gitHubTokenSecret) ?
+				System.getenv("WDM_GIT_HUB_TOKEN_SECRET") : gitHubTokenSecret;
+
 		if (!isNullOrEmpty(gitHubTokenName)
 				&& !isNullOrEmpty(gitHubTokenSecret)) {
 			String userpass = gitHubTokenName + ":" + gitHubTokenSecret;


### PR DESCRIPTION
I want to support a global configuration for GitHub API token using environment variables.
What do you think ?
 