### PR TITLE
Prevent non-executable files being picked as driver executables

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/BrowserManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/BrowserManager.java
@@ -279,11 +279,8 @@ public abstract class BrowserManager {
 			for (Object f : array) {
 				driverInCache = f.toString();
 				log.trace("Checking {}", driverInCache);
-				if (driverInCache.contains(driverName)) {
-					if (!isExecutable(new File(driverInCache))) {
-						continue;
-					}
-
+				if (driverInCache.contains(driverName)
+						&& isExecutable(new File(driverInCache))) {
 					log.info("Found {} in cache: {} ", driverName,
 							driverInCache);
 					break;


### PR DESCRIPTION
Fixes an issue we had when the download of phantomjs was interrupted and the tarball remained in the cache unextracted. Instead of redownloading the binary tarball and extracting it, the BrowserManager insisted on exporting the (corrupted) tarball as the driver executable.