### PR TITLE
#206 - better handling of latest version download

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/Config.java
@@ -66,6 +66,8 @@ public class Config {
     ConfigKey<Boolean> avoidOutputTree = new ConfigKey<>("wdm.avoidOutputTree",
             Boolean.class);
     ConfigKey<Integer> timeout = new ConfigKey<>("wdm.timeout", Integer.class);
+    ConfigKey<Boolean> latestVersion = new ConfigKey<>("wdm.useLatestVersion",
+            Boolean.class);
 
     ConfigKey<String> architecture = new ConfigKey<>("wdm.architecture",
             String.class, defaultArchitecture());
@@ -287,6 +289,15 @@ public class Config {
 
     public Config setTimeout(int value) {
         this.timeout.setValue(value);
+        return this;
+    }
+
+    public boolean isUseLatestVersion() {
+        return resolve(latestVersion);
+    }
+
+    public Config setLatestVersion(boolean value) {
+        this.latestVersion.setValue(value);
         return this;
     }
 

--- a/src/main/java/io/github/bonigarcia/wdm/FirefoxDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/FirefoxDriverManager.java
@@ -16,13 +16,13 @@
  */
 package io.github.bonigarcia.wdm;
 
-import static io.github.bonigarcia.wdm.DriverManagerType.FIREFOX;
-import static io.github.bonigarcia.wdm.OperatingSystem.MAC;
-import static java.util.Arrays.asList;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+
+import static io.github.bonigarcia.wdm.DriverManagerType.FIREFOX;
+import static io.github.bonigarcia.wdm.OperatingSystem.MAC;
+import static java.util.Arrays.asList;
 
 /**
  * Manager for Firefox.
@@ -43,6 +43,7 @@ public class FirefoxDriverManager extends WebDriverManager {
         driverUrlKey = "wdm.geckoDriverUrl";
         driverMirrorUrlKey = "wdm.geckoDriverMirrorUrl";
         driverName = asList("wires", "geckodriver");
+        latestVersion = "wdm.latestVersion";
     }
 
     @Override

--- a/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/OperaDriverManager.java
@@ -16,13 +16,13 @@
  */
 package io.github.bonigarcia.wdm;
 
-import static io.github.bonigarcia.wdm.DriverManagerType.OPERA;
-import static java.util.Arrays.asList;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+
+import static io.github.bonigarcia.wdm.DriverManagerType.OPERA;
+import static java.util.Arrays.asList;
 
 /**
  * Manager for Opera.
@@ -43,6 +43,7 @@ public class OperaDriverManager extends WebDriverManager {
         driverUrlKey = "wdm.operaDriverUrl";
         driverMirrorUrlKey = "wdm.operaDriverMirrorUrl";
         driverName = asList("operadriver");
+        latestVersion = "wdm.latestVersion";
     }
 
     @Override

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -407,16 +407,18 @@ public abstract class WebDriverManager {
                     || version.equalsIgnoreCase("latest");
             boolean cache = config().isForceCache() || !isNetAvailable();
 
-            if (instanceMap.containsKey(CHROME) && useLatestVersion && !cache) {
-                String url = config().getDriverUrl(driverUrlKey) + LATEST_VERSION_TAG;
+            if (driverName.contains("chromedriver")) {
+                if (version.isEmpty() && useLatestVersion && !cache) {
+                    String url = config().getDriverUrl(driverUrlKey) + LATEST_VERSION_TAG;
 
-                HttpGet request = new HttpGet(url);
-                request.addHeader("User-Agent", USER_AGENT);
+                    HttpGet request = new HttpGet(url);
+                    request.addHeader("User-Agent", USER_AGENT);
 
-                HttpResponse response = wdmHttpClient.execute(request);
-                BufferedReader rd = new BufferedReader(
-                        new InputStreamReader(response.getEntity().getContent()));
-                latestVersion = IOUtils.toString(rd);
+                    HttpResponse response = wdmHttpClient.execute(request);
+                    BufferedReader rd = new BufferedReader(
+                            new InputStreamReader(response.getEntity().getContent()));
+                    latestVersion = IOUtils.toString(rd);
+                }
             }
 
             String driverNameString = listToString(getDriverName());

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -855,7 +855,7 @@ public abstract class WebDriverManager {
                 GitHubApi[] releaseArray = gson.fromJson(reader,
                         GitHubApi[].class);
 
-                if (config().isUseLatestVersion()) {
+                if (useLatestVersion) {
                     driverVersion = releaseArray[0].getTagName();
                 }
 

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -855,7 +855,7 @@ public abstract class WebDriverManager {
                 GitHubApi[] releaseArray = gson.fromJson(reader,
                         GitHubApi[].class);
 
-                if (useLatestVersion) {
+                if (useLatestVersion && driverVersion != null) {
                     driverVersion = releaseArray[0].getTagName();
                 }
 

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -71,6 +71,7 @@ public abstract class WebDriverManager {
     static final Logger log = getLogger(lookup().lookupClass());
 
     protected static final String SLASH = "/";
+    protected static final String LATEST_VERSION_TAG = "LATEST_RELEASE";
 
     protected abstract List<URL> getDrivers() throws IOException;
 
@@ -407,7 +408,7 @@ public abstract class WebDriverManager {
             boolean cache = config().isForceCache() || !isNetAvailable();
 
             if (instanceMap.containsKey(CHROME) && useLatestVersion && !cache) {
-                String url = config().getDriverUrl(driverUrlKey) + "LATEST_RELEASE";
+                String url = config().getDriverUrl(driverUrlKey) + LATEST_VERSION_TAG;
 
                 HttpGet request = new HttpGet(url);
                 request.addHeader("User-Agent", USER_AGENT);

--- a/src/main/resources/webdrivermanager.properties
+++ b/src/main/resources/webdrivermanager.properties
@@ -3,10 +3,10 @@ wdm.forceCache=false
 wdm.override=false
 wdm.useMirror=false
 wdm.useBetaVersions=false
+wdm.useLatestVersion=true
 wdm.avoidExport=false
 wdm.avoidOutputTree=false
 wdm.timeout=30
-wdm.useLatestVersion=true
 
 wdm.chromeDriverUrl=https://chromedriver.storage.googleapis.com/
 wdm.chromeDriverMirrorUrl=http://npm.taobao.org/mirrors/chromedriver

--- a/src/main/resources/webdrivermanager.properties
+++ b/src/main/resources/webdrivermanager.properties
@@ -6,6 +6,7 @@ wdm.useBetaVersions=false
 wdm.avoidExport=false
 wdm.avoidOutputTree=false
 wdm.timeout=30
+wdm.useLatestVersion=true
 
 wdm.chromeDriverUrl=https://chromedriver.storage.googleapis.com/
 wdm.chromeDriverMirrorUrl=http://npm.taobao.org/mirrors/chromedriver


### PR DESCRIPTION
During merge of this PR it would be nice to add wdm.useLatestVersion parameter to documentation w/ description.

This change still don't handle latest versions of 
1) IE driver, because of open issue: https://github.com/SeleniumHQ/selenium/issues/4978
2) phantomJS - because it don't have any available possibility to check latest version