### PR TITLE
add support for Firefox62

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -16,6 +16,7 @@ chrome60=2.33
 
 # Browser: Mozilla Firefox - Driver: geckodriver
 # Source: https://github.com/mozilla/geckodriver/releases
+firefox62=0.22.0
 firefox61=0.21.0
 firefox60=0.21.0
 firefox59=0.21.0

--- a/src/test/java/io/github/bonigarcia/wdm/test/CacheTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/CacheTest.java
@@ -93,10 +93,10 @@ public class CacheTest {
                 String.class);
         method.setAccessible(true);
 
-        Optional<String> driverInChachePath = (Optional<String>) method
+        Optional<String> driverInCachePath = (Optional<String>) method
                 .invoke(browserManager, driverVersion, architecture, "");
 
-        assertThat(driverInChachePath.get(), notNullValue());
+        assertThat(driverInCachePath.get(), notNullValue());
     }
 
 }


### PR DESCRIPTION
@bonigarcia We need to make a new release with this change asap.
Currently our tests load geckodriver from github all the time, and often get 403 error. 