### PR TITLE
Fix: unable to determine Firefox version in headless mode

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/Shell.java
+++ b/src/main/java/io/github/bonigarcia/wdm/Shell.java
@@ -44,7 +44,7 @@ public class Shell {
         return runAndWaitArray(command);
     }
 
-    public static String runAndWaitArray(String[] command) {
+    private static String runAndWaitArray(String[] command) {
         String commandStr = Arrays.toString(command);
         log.trace("Running command on the shell: {}", commandStr);
         String result = runAndWaitNoLog(command);
@@ -52,11 +52,11 @@ public class Shell {
         return result;
     }
 
-    public static String runAndWaitNoLog(String... command) {
+    private static String runAndWaitNoLog(String... command) {
         String output = "";
         try {
             Process process = new ProcessBuilder(command)
-                    .redirectErrorStream(true).start();
+                    .redirectErrorStream(false).start();
             output = IOUtils.toString(process.getInputStream(), UTF_8);
             process.destroy();
         } catch (IOException e) {

--- a/src/test/java/io/github/bonigarcia/wdm/FakeFirefox.java
+++ b/src/test/java/io/github/bonigarcia/wdm/FakeFirefox.java
@@ -1,0 +1,20 @@
+package io.github.bonigarcia.wdm;
+
+public class FakeFirefox {
+    public static final String VERSION = "Mozilla Firefox 63.0.3";
+    public static final String HEADLESS_NOTICE = "*** You are running in headless mode.";
+
+    public static void main(String... args) {
+        System.err.println(HEADLESS_NOTICE);
+        System.out.println(VERSION);
+    }
+
+    public static String[] invocation() {
+        return new String[]{
+                "java",
+                "-cp",
+                "target/test-classes",
+                FakeFirefox.class.getCanonicalName()
+        };
+    }
+}

--- a/src/test/java/io/github/bonigarcia/wdm/ShellTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/ShellTest.java
@@ -1,0 +1,34 @@
+package io.github.bonigarcia.wdm;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ShellTest {
+    @Test
+    public void runAndWait_headlessFirefox_doesNotIncludeHeadlessNotice() {
+        String version = Shell.runAndWait(FakeFirefox.invocation());
+
+        assertThat(version, not(containsString(FakeFirefox.HEADLESS_NOTICE)));
+        assertThat(version, equalTo(FakeFirefox.VERSION));
+    }
+
+    @Test
+    public void getVersionFromPosixOutput_firefoxOutput_returnsMajorVersion() {
+        String version = Shell.getVersionFromPosixOutput(
+                "Mozilla Firefox 63.0.3",
+                "Mozilla Firefox");
+
+        assertThat(version, equalTo("63"));
+    }
+
+    @Test
+    public void getVersionFromPosixOutput_chromeOutput_returnsMajorVersion() {
+        String version = Shell.getVersionFromPosixOutput(
+                "Google Chrome 70.0.3538.110",
+                "Google Chrome");
+
+        assertThat(version, equalTo("70"));
+    }
+}


### PR DESCRIPTION
Fixes #282