### PR TITLE
chromedriver storage non-directory url path support

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -1016,7 +1016,7 @@ public abstract class WebDriverManager {
 
                 for (int i = 0; i < nodes.getLength(); ++i) {
                     Element e = (Element) nodes.item(i);
-                    urls.add(new URL(driverUrl
+                    urls.add(new URL(driverUrl.toURI().resolve(".")
                             + e.getChildNodes().item(0).getNodeValue()));
                 }
             }


### PR DESCRIPTION
Related to 
https://github.com/bonigarcia/webdrivermanager/issues/233#issuecomment-412922145
https://stackoverflow.com/questions/50702219/using-webdrivermanager-properties-file-with-artifactory

This change adds ability to keep xml configuration in xml-file-url like https://my-artifactory.com/chromedriver/index.xml
Original url https://chromedriver.storage.googleapis.com/ is still working