### PR TITLE
Edge Driver: Avoid ArrayIndexOutOfBoundsException - use sibling HTML paragraphs instead of guessing the order

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/EdgeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/EdgeDriverManager.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import java.util.stream.Collectors;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -103,31 +104,24 @@ public class EdgeDriverManager extends WebDriverManager {
                 .getContent()) {
             Document doc = parse(in, null, "");
 
-            Elements downloadLink = doc
+            Elements downloadLinks = doc
                     .select("ul.driver-downloads li.driver-download > a");
-            Elements versionParagraph = doc.select(
-                    "ul.driver-downloads li.driver-download p.driver-download__meta");
+            List<Optional<Element>> versionParagraph = downloadLinks.stream()
+                  .map(link->link.parent().select("p.driver-download__meta"))
+                  .map(paragraphs->paragraphs.size() == 1 ? Optional.of(paragraphs.get(0)) : Optional.<Element>empty())
+                  .collect(Collectors.toList());
 
-            log.trace("[Original] Download links:\n{}", downloadLink);
-            log.trace("[Original] Version paragraphs:\n{}", versionParagraph);
-            // Remove non-necessary paragraphs and links elements
-            downloadLink.remove(0);
-            versionParagraph.remove(0);
-            versionParagraph.remove(0);
-            versionParagraph.remove(3);
-            versionParagraph.remove(3);
-            versionParagraph.remove(3);
-            versionParagraph.remove(3);
-            log.trace("[Clean] Download links:\n{}", downloadLink);
-            log.trace("[Clean] Version paragraphs:\n{}", versionParagraph);
-
-            int shiftLinks = versionParagraph.size() - downloadLink.size();
-            log.trace(
-                    "The difference between the size of versions and links is {}",
-                    shiftLinks);
+            log.trace("Download links:\n{}", downloadLinks);
+            log.trace("Sibling version paragraphs:\n{}", versionParagraph);
 
             for (int i = 0; i < versionParagraph.size(); i++) {
-                Element paragraph = versionParagraph.get(i);
+                Element downloadLink = downloadLinks.get(i);
+                Optional<Element> optionalParagraph = versionParagraph.get(i);
+                if ( !optionalParagraph.isPresent() ) {
+                    log.trace("No describing paragraph was found for download link {}.", downloadLink);
+                    continue;
+                }
+                Element paragraph = optionalParagraph.get();
                 String[] version = paragraph.text().split(" ");
                 String v = version[1];
                 listVersions.add(v);
@@ -148,7 +142,7 @@ public class EdgeDriverManager extends WebDriverManager {
                     // Older versions
                     if (!v.equalsIgnoreCase("version")) {
                         urlList.add(new URL(
-                                downloadLink.get(i - shiftLinks).attr("href")));
+                                downloadLink.attr("href")));
                     }
                 }
             }


### PR DESCRIPTION
### Purpose of changes
I encountered an ArrayIndexOutOfBoundsException when trying to download Edge Driver from the updated Microsoft site. As the previous code was making assumptions about the number of paragraphs on the page I removed the old "guessing" code. Instead it looks for the download links, first. Then, from every link goes one dom element upwards and searches for the proper paragraph in there.

### Types of changes

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I simply ran it manually. The automated test were failing before and after the change.
