### PR TITLE
Added support for artifactory based mirrors.

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -1013,25 +1013,23 @@ public abstract class WebDriverManager {
         }
 
         String driverStr = driverUrl.toString();
-        String driverUrlContent = driverUrl.getPath();
 
         HttpResponse response = httpClient
                 .execute(httpClient.createHttpGet(driverUrl));
         try (InputStream in = response.getEntity().getContent()) {
-            org.jsoup.nodes.Document doc = Jsoup.parse(in, null, "");
+            org.jsoup.nodes.Document doc = Jsoup.parse(in, null, driverStr);
             Iterator<org.jsoup.nodes.Element> iterator = doc.select("a")
                     .iterator();
             List<URL> urlList = new ArrayList<>();
 
             while (iterator.hasNext()) {
-                String link = iterator.next().attr("href");
-                if (link.contains("mirror") && link.endsWith(SLASH)) {
-                    urlList.addAll(getDriversFromMirror(new URL(
-                            driverStr + link.replace(driverUrlContent, ""))));
-                } else if (link.startsWith(driverUrlContent)
-                        && !link.contains("icons")) {
-                    urlList.add(new URL(
-                            driverStr + link.replace(driverUrlContent, "")));
+                String link = iterator.next().attr("abs:href");
+                if (link.startsWith(driverStr) && link.endsWith(SLASH)) {
+                    urlList.addAll(getDriversFromMirror(new URL(link)));
+                } else if (link.startsWith(driverStr) && !link.contains("icons") && (link.toLowerCase().endsWith(".bz2")
+                                                                                  || link.toLowerCase().endsWith(".zip")
+                                                                                  || link.toLowerCase().endsWith(".gz"))) {
+                    urlList.add(new URL(link));
                 }
             }
             return urlList;

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -1028,6 +1028,7 @@ public abstract class WebDriverManager {
                     urlList.addAll(getDriversFromMirror(new URL(link)));
                 } else if (link.startsWith(driverStr) && !link.contains("icons") && (link.toLowerCase().endsWith(".bz2")
                                                                                   || link.toLowerCase().endsWith(".zip")
+                                                                                  || link.toLowerCase().endsWith(".msi")
                                                                                   || link.toLowerCase().endsWith(".gz"))) {
                     urlList.add(new URL(link));
                 }


### PR DESCRIPTION
### Purpose of changes
After this feature got merged: https://github.com/bonigarcia/webdrivermanager/pull/379 It is now possible to specify custom mirrors. What is extremely usefull for companies behind a firewall.

Unfortunatelly there is a problem. 
Current implementation of getDriversFromMirror method allows to download drivers only from those mirrors, which either have "mirror" in it's URL or those which have full absolute path links to drivers. But such approach won't work in case of artifactory or any other proxy based mirror for chrome webdriver page.

This pull request tries to address this issue and make mirror download more flexible.


### Types of changes
- [ x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### How has this been tested?
 All existing download, which are covered with unit tests should work. Also tried against internal artifactory instance.