### PR TITLE
use try-with for Inputstream

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/ChromeDriverManager.java
@@ -114,10 +114,9 @@ public class ChromeDriverManager extends WebDriverManager {
             url = config().getChromeDriverMirrorUrl() + "LATEST_RELEASE";
         }
         Optional<String> version = Optional.empty();
-        try {
-            InputStream response = httpClient
+        try (InputStream response = httpClient
                     .execute(httpClient.createHttpGet(new URL(url))).getEntity()
-                    .getContent();
+                    .getContent()){
             version = Optional.of(IOUtils.toString(response, defaultCharset()));
         } catch (Exception e) {
             log.warn("Exception reading {} to get latest version of {}", url,

--- a/src/main/java/io/github/bonigarcia/wdm/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/Config.java
@@ -227,9 +227,8 @@ public class Config {
 
     private String getPropertyFrom(String properties, String key) {
         Properties props = new Properties();
-        try {
-            InputStream inputStream = Config.class
-                    .getResourceAsStream(properties);
+        try (InputStream inputStream = Config.class
+                    .getResourceAsStream(properties)){
             props.load(inputStream);
         } catch (IOException e) {
             log.trace("Property {} not found in {}", key, properties);

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -683,11 +683,9 @@ public abstract class WebDriverManager {
             log.trace("Already created versions.properties");
             return versionsProperties;
         } else {
-            try {
-                InputStream inputStream = getVersionsInputStream(online);
+            try (InputStream inputStream = getVersionsInputStream(online)){
                 versionsProperties = new Properties();
                 versionsProperties.load(inputStream);
-                inputStream.close();
             } catch (Exception e) {
                 versionsProperties = null;
                 throw new IllegalStateException(


### PR DESCRIPTION
### Purpose of changes
On a few lines, the inputstream was created inside the try { block, without a proper call to close(). Since InputStream is autocloseable, use the try-with-resources statement. 

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
testsuite has been run
