### PR TITLE
Fix proxy credentials never set from env vars

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/HttpClient.java
+++ b/src/main/java/io/github/bonigarcia/wdm/HttpClient.java
@@ -237,8 +237,8 @@ public class HttpClient implements Closeable {
         password = (envProxyPass != null) ? envProxyPass : password;
 
         // apply option value
-        username = (proxyUser != null) ? proxyUser : username;
-        password = (proxyPass != null) ? proxyPass : password;
+        username = isNullOrEmpty(proxyUser) ? username : proxyUser;
+        password = isNullOrEmpty(proxyPass) ? password : proxyPass;
 
         if (username == null) {
             return empty();


### PR DESCRIPTION
### Purpose of changes
When configuring a proxy using environment variables the credentials would be lost.

### Types of changes
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I struggled to write a unit test for this in the time I had available. In the end I manually tested it by running TaoBaoTest behind a proxy that needed authentication. Without this fix it did not work, with the fix it worked well. It's a straightforward issue, seems like `config.getProxyUser()` and `config.getProxyPass()` return empty string instead of null, hence the need to check for both.
