### PR TITLE
Add Safari support for DriverManagerType

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/DriverManagerType.java
+++ b/src/main/java/io/github/bonigarcia/wdm/DriverManagerType.java
@@ -31,7 +31,8 @@ public enum DriverManagerType {
     PHANTOMJS("org.openqa.selenium.phantomjs.PhantomJSDriver"),
     IEXPLORER("org.openqa.selenium.ie.InternetExplorerDriver"),
     SELENIUM_SERVER_STANDALONE("org.openqa.selenium.remote.server.SeleniumServer"),
-    CHROMIUM("org.openqa.selenium.chrome.ChromeDriver");
+    CHROMIUM("org.openqa.selenium.chrome.ChromeDriver"),
+    SAFARI("org.openqa.selenium.safari.SafariDriver");
 
     String browserClass;
 
@@ -60,6 +61,8 @@ public enum DriverManagerType {
             return "PhantomJS";
         case IEXPLORER:
             return "Internet Explorer";
+            case SAFARI:
+                return "Safari";
         case SELENIUM_SERVER_STANDALONE:
             return "Selenium Server Standalone";
         default:

--- a/src/test/java/io/github/bonigarcia/wdm/test/DriverManagerTypeTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/DriverManagerTypeTest.java
@@ -56,6 +56,7 @@ public class DriverManagerTypeTest {
                 { "org.openqa.selenium.edge.EdgeDriver", DriverManagerType.EDGE },
                 { "org.openqa.selenium.phantomjs.PhantomJSDriver", DriverManagerType.PHANTOMJS },
                 { "org.openqa.selenium.ie.InternetExplorerDriver", DriverManagerType.IEXPLORER },
+                { "org.openqa.selenium.safari.SafariDriver", DriverManagerType.SAFARI },
                 { "org.openqa.selenium.remote.server.SeleniumServer", DriverManagerType.SELENIUM_SERVER_STANDALONE } });
     }
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/SafariTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/SafariTest.java
@@ -1,0 +1,44 @@
+/*
+ * (C) Copyright 2015 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.bonigarcia.wdm.test;
+
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC_OSX;
+import static org.junit.Assume.assumeTrue;
+
+import io.github.bonigarcia.wdm.base.BrowserTestParent;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.openqa.selenium.safari.SafariDriver;
+
+/**
+ * Test with Safari
+ *
+ * @author Elias Nogueira (elias.nogueira@gmail.com)
+ * @since 3.8.2
+ */
+public class SafariTest extends BrowserTestParent {
+
+    @BeforeClass
+    public static void setupClass() {
+        assumeTrue(IS_OS_MAC_OSX);
+    }
+
+    @Before
+    public void setupTest() {
+        driver = new SafariDriver();
+    }
+}

--- a/src/test/java/io/github/bonigarcia/wdm/test/SafariTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/SafariTest.java
@@ -16,7 +16,7 @@
  */
 package io.github.bonigarcia.wdm.test;
 
-import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC_OSX;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC;
 import static org.junit.Assume.assumeTrue;
 
 import io.github.bonigarcia.wdm.base.BrowserTestParent;
@@ -34,7 +34,7 @@ public class SafariTest extends BrowserTestParent {
 
     @BeforeClass
     public static void setupClass() {
-        assumeTrue(IS_OS_MAC_OSX);
+        assumeTrue(IS_OS_MAC);
     }
 
     @Before


### PR DESCRIPTION
### Purpose of changes
This implements and closes #449

### Types of changes
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Through a change in `DriverManagerTypeTest` class adding Safari and a new class `SafariTest` to make sure Safari will open on a MacOSX machine.
