### PR TITLE
Add versions match for Edge on MacOSX

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/EdgeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/EdgeDriverManager.java
@@ -25,6 +25,7 @@ import static io.github.bonigarcia.wdm.Shell.runAndWait;
 import static java.util.Collections.sort;
 import static java.util.Optional.empty;
 import static org.apache.commons.io.FileUtils.listFiles;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC_OSX;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.jsoup.Jsoup.parse;
 
@@ -38,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -214,8 +216,9 @@ public class EdgeDriverManager extends WebDriverManager {
 
     @Override
     protected Optional<String> getBrowserVersion() {
+        String[] programFilesEnvs = { getProgramFilesEnv() };
+
         if (IS_OS_WINDOWS) {
-            String[] programFilesEnvs = { getProgramFilesEnv() };
             String[] msEdgePaths = {
                     "\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe",
                     "\\\\Microsoft\\\\Edge Beta\\\\Application\\\\msedge.exe",
@@ -244,7 +247,12 @@ public class EdgeDriverManager extends WebDriverManager {
                 return Optional.of(
                         getVersionFromPowerShellOutput(browserVersionOutput));
             }
+        }
+        if (IS_OS_MAC_OSX) {
+            String macBrowserName = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
 
+            return getDefaultBrowserVersion(programFilesEnvs, StringUtils.EMPTY, StringUtils.EMPTY, macBrowserName,
+                "-version", getDriverManagerType().toString());
         }
         return empty();
     }

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeMacVersion.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeMacVersion.java
@@ -1,0 +1,46 @@
+/*
+ * (C) Copyright 2015 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.bonigarcia.wdm.test;
+
+import static io.github.bonigarcia.wdm.OperatingSystem.MAC;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import io.github.bonigarcia.wdm.base.VersionTestParent;
+import org.junit.Before;
+import org.openqa.selenium.edge.EdgeDriver;
+
+/**
+ * Test asserting Edge driver versions on MacOSX.
+ * This is a separate class because the Win versus MacOSX versions aren't the same
+ * Please take a look at https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+ *
+ * @author Elias Nogueira (elias.nogueira@gmail.com)
+ * @since 3.8.2
+ */
+public class EdgeMacVersion extends VersionTestParent {
+
+    @Before
+    public void setup() {
+        browserManager = WebDriverManager.getInstance(EdgeDriver.class);
+        os = MAC;
+        specificVersions = new String[] {
+            "80.0.361.62", "80.0.361.66", "80.0.361.69",
+            "81.0.416.28", "81.0.416.31", "81.0.416.34",
+            "82.0.456.0", "82.0.457.0", "82.0.458.0"
+        };
+    }
+}

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeMacVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeMacVersionTest.java
@@ -31,7 +31,7 @@ import org.openqa.selenium.edge.EdgeDriver;
  * @author Elias Nogueira (elias.nogueira@gmail.com)
  * @since 3.8.2
  */
-public class EdgeMacVersion extends VersionTestParent {
+public class EdgeMacVersionTest extends VersionTestParent {
 
     @Before
     public void setup() {

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeTest.java
@@ -16,6 +16,7 @@
  */
 package io.github.bonigarcia.wdm.test;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.junit.Assume.assumeTrue;
 
@@ -36,7 +37,7 @@ public class EdgeTest extends BrowserTestParent {
 
     @BeforeClass
     public static void setupClass() {
-        assumeTrue(IS_OS_WINDOWS);
+        assumeTrue(IS_OS_WINDOWS || IS_OS_MAC);
         WebDriverManager.edgedriver().setup();
     }
 

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeWindowsVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeWindowsVersionTest.java
@@ -25,12 +25,12 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.base.VersionTestParent;
 
 /**
- * Test asserting Edge driver versions.
+ * Test asserting Edge driver versions on Windows.
  *
  * @author Boni Garcia (boni.gg@gmail.com)
  * @since 1.3.0
  */
-public class EdgeVersionTest extends VersionTestParent {
+public class EdgeWindowsVersionTest extends VersionTestParent {
 
     @Before
     public void setup() {


### PR DESCRIPTION
### Purpose of changes
Implements and close #447 to support Edge browser on MacOSX

### Types of changes
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Through a new test class `EdgeMacVersionTest`
