### PR TITLE
Handle Nexus Repository Manager mirrors

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -1050,6 +1050,7 @@ public abstract class WebDriverManager {
         }
 
         String driverStr = driverUrl.toString();
+        String driverOrigin = String.format("%s://%s", driverUrl.getProtocol(), driverUrl.getAuthority());
 
         HttpResponse response = httpClient
                 .execute(httpClient.createHttpGet(driverUrl));
@@ -1063,7 +1064,7 @@ public abstract class WebDriverManager {
                 String link = iterator.next().attr("abs:href");
                 if (link.startsWith(driverStr) && link.endsWith(SLASH)) {
                     urlList.addAll(getDriversFromMirror(new URL(link)));
-                } else if (link.startsWith(driverStr) && !link.contains("icons")
+                } else if (link.startsWith(driverOrigin) && !link.contains("icons")
                         && (link.toLowerCase().endsWith(".bz2")
                                 || link.toLowerCase().endsWith(".zip")
                                 || link.toLowerCase().endsWith(".msi")


### PR DESCRIPTION
### Purpose of changes
This change allows Webdrivermanager to use Nexus Repository Manager 3 raw repositories as a download mirror.

**Problem**
We use Nexus Repository Manager as mirror for our webdrivers. The behavior of Nexus is different - the directory listings come from a REST url, for example we set this:
`wdm.chromeDriverMirrorUrl=http://nexus.example.com/nexus/service/rest/repository/browse/mirror/chromedriver/`

Which gives us links that point somewhere else on the Nexus instance, e.g. this:
`http://nexus.example.com/repository/mirror/chromedriver/2.40/chromedriver_linux64.zip`

Because the driver URL does not `startsWith` mirror URL Webdrivermanager refuses to follow these links.

**Solution**
There were three choices (I have currently chosen Option 2), all affecting [this line of code](https://github.com/bonigarcia/webdrivermanager/blob/a5ca27fde34a0794ede3141b9da260e6ddee9add/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java#L1064):

```java
} else if (link.startsWith(driverStr) && !link.contains("icons")
```

1. Simply remove the "startsWith" check completely, I was very tempted to go this option. Does it matter where the driver binary is located? The code would become this:

```java
} else if (!link.contains("icons")
```

2. Do a "same origin" check on the URL. While I do not know why these links are checked, if it is for the purposes of security then this ought to suffice.

```java
} else if (link.startsWith(driverOrigin) && !link.contains("icons")
```

3. Leave the behavior as is but put the behavior of Option 1 behind a flag, something like this:

```java
} else if ((config.isAvoidOriginCheck() || link.startsWith(driverStr)) && !link.contains("icons")
```

If you'd prefer me to update the PR with any of the alternate options let me know.

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I have tested this against our Nexus Repository Manager instance and also against the taobao mirror which continues to work as before. 
