### PR TITLE
Support Windows 8.3 short names in targetPath

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/Config.java
@@ -291,10 +291,10 @@ public class Config {
 
         if (resolved != null) {
             path = resolved;
-            if (path.contains(HOME)) {
-                path = path.replace(HOME, System.getProperty("user.home"));
-            }
-            if (path.equals(".")) {
+            // Partial support for Bash tilde expansion: http://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
+            if (path.startsWith(HOME + '/')) {
+                path = Paths.get(System.getProperty("user.home"), path.substring(1)).toString();
+            } else if (path.equals(".")) {
                 path = Paths.get("").toAbsolutePath().toString();
             }
         }


### PR DESCRIPTION
We're hoping there'll be a new release soon 😇 and have addressed this issue for you in case this was holding things up, since you have scheduled it for the next release... 

### Purpose of changes
Resolves #440 

Note the following:

* Only partially implements Bash's [tilde expansion](http://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html) but this is probably all that is needed. For example `~anotheruser/path` (expands to a different user's home directory) is not implemented, I think this is fine? Anyway I think it would be difficult to implement in a reliable cross-platform manner.
* It will work on both Linux and Windows.
* 8.3 names will "just work" now, I see no need to expand them to their long name form.

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
New unit tests are included, have run them on Windows and Linux.
