### PR TITLE
Fix TravisCI YML syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
-sudo: false
+
+os: linux
+
 dist: xenial
+
 install: true
 
 services:


### PR DESCRIPTION
Removes 'sudo' keyword that became obsolete
Adds the 'os' keyword to follow the syntax rules

### Purpose of changes
Keep the CI pipeline up to date

### Types of changes
- [ X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Travis CI
