### PR TITLE
Adding all Edge versions

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -73,8 +73,8 @@ opera46=2.29
 
 # Browser: Microsoft Edge - Driver: msedgedriver
 # Source: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
-edge81=81.0.416.34
-edge80=80.0.361.69
+edge81=81.0.410.0
+edge80=80.0.361.111
 edge79=79.0.313.0
 edge78=78.0.277.0
 edge77=77.0.237.0

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeLegacyWindowsVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeLegacyWindowsVersionTest.java
@@ -16,11 +16,17 @@
  */
 package io.github.bonigarcia.wdm.test;
 
+import static io.github.bonigarcia.wdm.OperatingSystem.*;
 import static java.lang.invoke.MethodHandles.lookup;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import io.github.bonigarcia.wdm.Config;
+import io.github.bonigarcia.wdm.OperatingSystem;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,15 +41,19 @@ import io.github.bonigarcia.wdm.WebDriverManager;
  * @author Boni Garcia (boni.gg@gmail.com)
  * @since 3.5.0
  */
-public class EdgeReadVersionTest {
+public class EdgeLegacyWindowsVersionTest {
 
     final Logger log = getLogger(lookup().lookupClass());
 
     @Test
     public void edgeVersionsTest() {
-        String[] expectedVersions = { "1.10240", "2.10586", "3.14393",
+        Config config = new Config();
+        config.setOs(WIN.toString());
+
+        String baseVersion = "1.10240";
+        String[] expectedVersions = { baseVersion, "2.10586", "3.14393",
                 "4.15063", "5.16299", "6.17134" };
-        List<String> versions = WebDriverManager.edgedriver().getVersions();
+        List<String> versions = WebDriverManager.edgedriver().version(baseVersion).getVersions();
 
         log.debug("Expected edge versions: {}",
                 Arrays.asList(expectedVersions));

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeMacVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeMacVersionTest.java
@@ -18,6 +18,7 @@ package io.github.bonigarcia.wdm.test;
 
 import static io.github.bonigarcia.wdm.OperatingSystem.MAC;
 
+import io.github.bonigarcia.wdm.Architecture;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.base.VersionTestParent;
 import org.junit.Before;
@@ -37,10 +38,20 @@ public class EdgeMacVersionTest extends VersionTestParent {
     public void setup() {
         browserManager = WebDriverManager.getInstance(EdgeDriver.class);
         os = MAC;
+        architecture = Architecture.X64;
+
+        // latest of each major version
         specificVersions = new String[] {
-            "80.0.361.62", "80.0.361.66", "80.0.361.69",
-            "81.0.416.28", "81.0.416.31", "81.0.416.34",
-            "82.0.456.0", "82.0.457.0", "82.0.458.0"
+            "75.0.139.20",
+            "76.0.183.0",
+            "77.0.235.7",
+            "78.0.277.0",
+            "79.0.313.0",
+            "80.0.361.9",
+            "81.0.410.0",
+            "82.0.459.1",
+            "83.0.478.18",
+            "84.0.498.0"
         };
     }
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeMsiTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeMsiTest.java
@@ -21,6 +21,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import io.github.bonigarcia.wdm.OperatingSystem;
 import java.io.File;
 
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class EdgeMsiTest {
 
     @Test
     public void testMsiInWindows() {
-        edgedriver().version("2.10586").setup();
+        edgedriver().version("2.10586").operatingSystem(OperatingSystem.WIN).setup();
         File binary = new File(edgedriver().getBinaryPath());
         log.debug("Edge driver {}", binary);
         assertTrue(binary.getName().endsWith(".exe"));

--- a/src/test/java/io/github/bonigarcia/wdm/test/EdgeWindowsVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/EdgeWindowsVersionTest.java
@@ -18,17 +18,17 @@ package io.github.bonigarcia.wdm.test;
 
 import static io.github.bonigarcia.wdm.OperatingSystem.WIN;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
+import io.github.bonigarcia.wdm.base.VersionTestParent;
 import org.junit.Before;
 import org.openqa.selenium.edge.EdgeDriver;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
-import io.github.bonigarcia.wdm.base.VersionTestParent;
-
 /**
- * Test asserting Edge driver versions on Windows.
+ * Test asserting Edge driver versions on MacOSX. This is a separate class because the Win versus MacOSX versions aren't
+ * the same Please take a look at https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
  *
- * @author Boni Garcia (boni.gg@gmail.com)
- * @since 1.3.0
+ * @author Elias Nogueira (elias.nogueira@gmail.com)
+ * @since 3.8.2
  */
 public class EdgeWindowsVersionTest extends VersionTestParent {
 
@@ -36,8 +36,10 @@ public class EdgeWindowsVersionTest extends VersionTestParent {
     public void setup() {
         browserManager = WebDriverManager.getInstance(EdgeDriver.class);
         os = WIN;
-        specificVersions = new String[] { "1.10240", "2.10586", "3.14393",
-                "4.15063", "5.16299", "6.17134" };
+        specificVersions = new String[]{
+            "79.0.313.0",
+            "80.0.361.111",
+            "81.0.410.0 "
+        };
     }
-
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/ServerTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/ServerTest.java
@@ -67,7 +67,7 @@ public class ServerTest {
                 { "firefoxdriver", "geckodriver" + EXT },
                 { "operadriver", "operadriver" + EXT },
                 { "phantomjs", "phantomjs" + EXT },
-                { "edgedriver", "msedgedriver.exe" },
+                { "edgedriver", "MicrosoftWebDriver" + EXT },
                 { "iedriver", "IEDriverServer.exe" },
                 { "chromedriver?os=WIN", "chromedriver.exe" },
                 { "chromedriver?os=LINUX&chromeDriverVersion=2.41&forceCache=true",


### PR DESCRIPTION
### Purpose of changes
This change fix #444 issue adding all the Edge drivers to WebDriverManager.

### Types of changes
🔴 This might introduce a breaking change, so it must be tested extensively.
My tests were done in a MacOSX environment. We must make sure it's working on a Windows environment.

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Through all tests related to the Edge and IE driver:
* EdgeLegacyWindowsVersionTest
* EdgeMacVersionTest
* EdgeMsiTest
* EdgePreInstalledTest
* EdgeTest
* EdgeWindowsVersionTest

### Additional tests should run
Running, manly the tests related to Edge and Legacy Edge. It should work:
* setting any existing Edge version we can found on [this page](https://msedgewebdriverstorage.z22.web.core.windows.net/), manly the ones not mentioned on [this page](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
* setting all the existing Microsoft Edge Legacy version mentioned in [this page](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
* Run all these tests on a Windows environment