### PR TITLE
Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '08:00'
+  open-pull-requests-limit: 99


### PR DESCRIPTION
# Adds Dependabot Configuration

Dependabot check for updates in the dependency list described on `pom.xml` and creates a pull request whenever if finds an outdated versions.

Dependabot now is fully integrated in the Github page! It will appear in section dependencies inside the tab Insights after enabled.

<https://github.com/bonigarcia/webdrivermanager/network/dependencies>

### Types of changes

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### CI on branch: <https://github.com/edumco/webdrivermanager/tree/dependabot-configuration>
