### PR TITLE
Add namespace context for Saxon compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.github.bonigarcia</groupId>
     <artifactId>webdrivermanager</artifactId>
-    <version>4.0.1-SP1-UM</version>
+    <version>4.0.1-SNAPSHOT</version>
 
     <properties>
         <slf4j.version>1.7.30</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.github.bonigarcia</groupId>
     <artifactId>webdrivermanager</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.1-SP1-UM</version>
 
     <properties>
         <slf4j.version>1.7.30</slf4j.version>

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -59,9 +59,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
@@ -818,7 +820,16 @@ public abstract class WebDriverManager {
         }
     }
 
+    protected NamespaceContext getNamespaceContext() {
+        return null;
+    }
+
     protected List<URL> getDriversFromXml(URL driverUrl, String xpath)
+            throws IOException {
+        return getDriversFromXml(driverUrl, xpath, getNamespaceContext());
+    }
+
+    protected List<URL> getDriversFromXml(URL driverUrl, String xpath, NamespaceContext namespaceContext)
             throws IOException {
         log.info("Reading {} to seek {}", driverUrl, getDriverName());
         List<URL> urls = new ArrayList<>();
@@ -826,9 +837,12 @@ public abstract class WebDriverManager {
             try (CloseableHttpResponse response = httpClient
                     .execute(httpClient.createHttpGet(driverUrl))) {
                 Document xml = loadXML(response.getEntity().getContent());
-                NodeList nodes = (NodeList) newInstance().newXPath()
+                XPath xPath = newInstance().newXPath();
+                if (namespaceContext != null){
+                    xPath.setNamespaceContext(namespaceContext);
+                }
+                NodeList nodes = (NodeList) xPath
                         .evaluate(xpath, xml.getDocumentElement(), NODESET);
-
                 for (int i = 0; i < nodes.getLength(); ++i) {
                     Element e = (Element) nodes.item(i);
                     urls.add(new URL(driverUrl.toURI().resolve(".")

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -858,6 +858,7 @@ public abstract class WebDriverManager {
     protected Document loadXML(InputStream inputStream)
             throws SAXException, IOException, ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         return builder.parse(new InputSource(
                 new ByteArrayInputStream(IOUtils.toByteArray(inputStream))));

--- a/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
+import io.github.bonigarcia.wdm.online.S3BucketListNamespaceContext;
 
 import javax.xml.namespace.NamespaceContext;
 
@@ -153,27 +154,6 @@ public class ChromeDriverManager extends WebDriverManager {
     @Override
     protected NamespaceContext getNamespaceContext() {
         return S3_BUCKET_LIST_NAMESPACE_CONTEXT;
-    }
-
-    private static final class S3BucketListNamespaceContext implements NamespaceContext {
-
-        private static final String S3_BUCKET_LIST_NS = "http://doc.s3.amazonaws.com/2006-03-01";
-
-        @Override
-        public String getNamespaceURI(String prefix) {
-            return S3_BUCKET_LIST_NS;
-        }
-
-        @Override
-        public String getPrefix(String namespaceURI) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Iterator getPrefixes(String namespaceURI) {
-            throw new UnsupportedOperationException();
-        }
-
     }
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
@@ -37,7 +37,7 @@ import javax.xml.namespace.NamespaceContext;
  * Manager for Chrome.
  *
  * @author Boni Garcia (boni.gg@gmail.com)
- * @since 1.0.0 Are we waiting for something? Last time I was able to hear you.
+ * @since 1.0.0
  */
 public class ChromeDriverManager extends WebDriverManager {
 

--- a/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
@@ -24,19 +24,24 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
 
+import javax.xml.namespace.NamespaceContext;
+
 /**
  * Manager for Chrome.
  *
  * @author Boni Garcia (boni.gg@gmail.com)
- * @since 1.0.0
+ * @since 1.0.0 Are we waiting for something? Last time I was able to hear you.
  */
 public class ChromeDriverManager extends WebDriverManager {
+
+    private static final S3BucketListNamespaceContext S3_BUCKET_LIST_NAMESPACE_CONTEXT = new S3BucketListNamespaceContext();
 
     @Override
     public DriverManagerType getDriverManagerType() {
@@ -94,7 +99,7 @@ public class ChromeDriverManager extends WebDriverManager {
         if (mirrorUrl.isPresent() && config().isUseMirror()) {
             return getDriversFromMirror(mirrorUrl.get());
         } else {
-            return getDriversFromXml(getDriverUrl(), "//Contents/Key");
+            return getDriversFromXml(getDriverUrl(), "//s3:Contents/s3:Key");
         }
     }
 
@@ -143,6 +148,32 @@ public class ChromeDriverManager extends WebDriverManager {
     @Override
     protected Charset getVersionCharset() {
         return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    protected NamespaceContext getNamespaceContext() {
+        return S3_BUCKET_LIST_NAMESPACE_CONTEXT;
+    }
+
+    private static final class S3BucketListNamespaceContext implements NamespaceContext {
+
+        private static final String S3_BUCKET_LIST_NS = "http://doc.s3.amazonaws.com/2006-03-01";
+
+        @Override
+        public String getNamespaceURI(String prefix) {
+            return S3_BUCKET_LIST_NS;
+        }
+
+        @Override
+        public String getPrefix(String namespaceURI) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterator getPrefixes(String namespaceURI) {
+            throw new UnsupportedOperationException();
+        }
+
     }
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/managers/InternetExplorerDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/InternetExplorerDriverManager.java
@@ -26,6 +26,9 @@ import java.util.Optional;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
+import io.github.bonigarcia.wdm.online.S3BucketListNamespaceContext;
+
+import javax.xml.namespace.NamespaceContext;
 
 /**
  * Manager for Internet Explorer.
@@ -34,6 +37,8 @@ import io.github.bonigarcia.wdm.config.DriverManagerType;
  * @since 1.0.0
  */
 public class InternetExplorerDriverManager extends WebDriverManager {
+
+    private static final S3BucketListNamespaceContext S3_BUCKET_LIST_NAMESPACE_CONTEXT = new S3BucketListNamespaceContext();
 
     @Override
     public DriverManagerType getDriverManagerType() {
@@ -87,7 +92,7 @@ public class InternetExplorerDriverManager extends WebDriverManager {
 
     @Override
     protected List<URL> getDriverUrls() throws IOException {
-        return getDriversFromXml(getDriverUrl(), "//Contents/Key");
+        return getDriversFromXml(getDriverUrl(), "//s3:Contents/s3:Key");
     }
 
     @Override
@@ -99,6 +104,11 @@ public class InternetExplorerDriverManager extends WebDriverManager {
     protected Optional<String> getDriverVersionFromRepository(
             Optional<String> driverVersion) {
         return empty();
+    }
+
+    @Override
+    protected NamespaceContext getNamespaceContext() {
+        return S3_BUCKET_LIST_NAMESPACE_CONTEXT;
     }
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/managers/SeleniumServerStandaloneManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/SeleniumServerStandaloneManager.java
@@ -27,6 +27,9 @@ import java.util.Optional;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
+import io.github.bonigarcia.wdm.online.S3BucketListNamespaceContext;
+
+import javax.xml.namespace.NamespaceContext;
 
 /**
  * Manager for selenium-server-standalone.
@@ -35,6 +38,8 @@ import io.github.bonigarcia.wdm.config.DriverManagerType;
  * @since 3.0.1
  */
 public class SeleniumServerStandaloneManager extends WebDriverManager {
+
+    private static final S3BucketListNamespaceContext S3_BUCKET_LIST_NAMESPACE_CONTEXT = new S3BucketListNamespaceContext();
 
     @Override
     public DriverManagerType getDriverManagerType() {
@@ -88,7 +93,7 @@ public class SeleniumServerStandaloneManager extends WebDriverManager {
 
     @Override
     protected List<URL> getDriverUrls() throws IOException {
-        return getDriversFromXml(getDriverUrl(), "//Contents/Key");
+        return getDriversFromXml(getDriverUrl(), "//s3:Contents/s3:Key");
     }
 
     @Override
@@ -105,6 +110,11 @@ public class SeleniumServerStandaloneManager extends WebDriverManager {
     @Override
     protected void setBrowserVersion(String browserVersion) {
         // Nothing required
+    }
+
+    @Override
+    protected NamespaceContext getNamespaceContext() {
+        return S3_BUCKET_LIST_NAMESPACE_CONTEXT;
     }
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/online/S3BucketListNamespaceContext.java
+++ b/src/main/java/io/github/bonigarcia/wdm/online/S3BucketListNamespaceContext.java
@@ -1,25 +1,58 @@
 package io.github.bonigarcia.wdm.online;
 
 import javax.xml.namespace.NamespaceContext;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 public class S3BucketListNamespaceContext implements NamespaceContext {
 
     private static final String S3_BUCKET_LIST_NS = "http://doc.s3.amazonaws.com/2006-03-01";
 
+    private static final String S3_PREFIX = "s3";
+
     @Override
     public String getNamespaceURI(String prefix) {
-        return S3_BUCKET_LIST_NS;
+        if (S3_PREFIX.equals(prefix)) {
+            return S3_BUCKET_LIST_NS;
+        }
+        throw new IllegalArgumentException("Unsupported prefix");
     }
 
     @Override
     public String getPrefix(String namespaceURI) {
-        throw new UnsupportedOperationException();
+        if (S3_BUCKET_LIST_NS.equals(namespaceURI)) {
+            return S3_PREFIX;
+        }
+        throw new IllegalArgumentException("Unsupported namespace URI");
     }
 
     @Override
-    public Iterator getPrefixes(String namespaceURI) {
-        throw new UnsupportedOperationException();
+    public Iterator<String> getPrefixes(String namespaceURI) {
+        if (S3_BUCKET_LIST_NS.equals(namespaceURI)) {
+            return new Iterator() {
+                boolean more = true;
+
+                public boolean hasNext() {
+                    return this.more;
+                }
+
+                public Object next() {
+                    if (!this.hasNext()) {
+                        throw new NoSuchElementException();
+                    } else {
+                        this.more = false;
+                        return S3_PREFIX;
+                    }
+                }
+
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        } else {
+            return Collections.EMPTY_LIST.iterator();
+        }
     }
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/online/S3BucketListNamespaceContext.java
+++ b/src/main/java/io/github/bonigarcia/wdm/online/S3BucketListNamespaceContext.java
@@ -30,26 +30,7 @@ public class S3BucketListNamespaceContext implements NamespaceContext {
     @Override
     public Iterator<String> getPrefixes(String namespaceURI) {
         if (S3_BUCKET_LIST_NS.equals(namespaceURI)) {
-            return new Iterator() {
-                boolean more = true;
-
-                public boolean hasNext() {
-                    return this.more;
-                }
-
-                public Object next() {
-                    if (!this.hasNext()) {
-                        throw new NoSuchElementException();
-                    } else {
-                        this.more = false;
-                        return S3_PREFIX;
-                    }
-                }
-
-                public void remove() {
-                    throw new UnsupportedOperationException();
-                }
-            };
+            return Collections.singletonList(S3_PREFIX).iterator();
         } else {
             return Collections.EMPTY_LIST.iterator();
         }

--- a/src/main/java/io/github/bonigarcia/wdm/online/S3BucketListNamespaceContext.java
+++ b/src/main/java/io/github/bonigarcia/wdm/online/S3BucketListNamespaceContext.java
@@ -1,0 +1,25 @@
+package io.github.bonigarcia.wdm.online;
+
+import javax.xml.namespace.NamespaceContext;
+import java.util.Iterator;
+
+public class S3BucketListNamespaceContext implements NamespaceContext {
+
+    private static final String S3_BUCKET_LIST_NS = "http://doc.s3.amazonaws.com/2006-03-01";
+
+    @Override
+    public String getNamespaceURI(String prefix) {
+        return S3_BUCKET_LIST_NS;
+    }
+
+    @Override
+    public String getPrefix(String namespaceURI) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator getPrefixes(String namespaceURI) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
@@ -9,28 +9,40 @@ import org.junit.Test;
 import javax.xml.namespace.NamespaceContext;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 
 public class NamespaceContextTest {
 
+    public static final S3BucketListNamespaceContext S_3_BUCKET_LIST_NAMESPACE_CONTEXT = new S3BucketListNamespaceContext();
+
+    public static final String S3_URI = "http://doc.s3.amazonaws.com/2006-03-01";
+
     @Test
     public void testS3BucketListNamespaceContext() throws IOException {
+        assertThat(S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getNamespaceURI("s3"), equalTo(S3_URI));
+        assertThat(S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefix(S3_URI), equalTo("s3"));
+        Iterator<String> prefixes = S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefixes(S3_URI);
+        assertThat(prefixes.next(), equalTo("s3"));
+        assertThat(prefixes.hasNext(), equalTo(false));
+
         TestWebDriverManager testManager = new TestWebDriverManager();
         List<URL> urls = testManager.getDriverUrls();
         assertThat(urls, is(not(empty())));
     }
 
-    private static final class TestWebDriverManager extends WebDriverManager{
+    private static final class TestWebDriverManager extends WebDriverManager {
 
         @Override
         protected NamespaceContext getNamespaceContext() {
-            return new S3BucketListNamespaceContext();
+            return S_3_BUCKET_LIST_NAMESPACE_CONTEXT;
         }
 
         @Override

--- a/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.fail;
 
 public class NamespaceContextTest {
 
@@ -26,16 +27,40 @@ public class NamespaceContextTest {
     public static final String S3_URI = "http://doc.s3.amazonaws.com/2006-03-01";
 
     @Test
-    public void testS3BucketListNamespaceContext() throws IOException {
+    public void testS3BucketListNamespaceContextUrls() throws IOException {
+        TestWebDriverManager testManager = new TestWebDriverManager();
+        List<URL> urls = testManager.getDriverUrls();
+        assertThat(urls, is(not(empty())));
+    }
+
+    @Test
+    public void testS3BucketListNamespaceContextPrefixes(){
         assertThat(S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getNamespaceURI("s3"), equalTo(S3_URI));
         assertThat(S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefix(S3_URI), equalTo("s3"));
         Iterator<String> prefixes = S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefixes(S3_URI);
         assertThat(prefixes.next(), equalTo("s3"));
         assertThat(prefixes.hasNext(), equalTo(false));
+    }
 
-        TestWebDriverManager testManager = new TestWebDriverManager();
-        List<URL> urls = testManager.getDriverUrls();
-        assertThat(urls, is(not(empty())));
+
+    @Test
+    public void testS3BucketListNamespaceContextInvalidPrefixes(){
+        try {
+            S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getNamespaceURI("xmlns");
+            fail("IllegalArgumentException should be thrown");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Unsupported prefix"));
+        }
+        try {
+            S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefix("http://www.w3.org/2000/xmlns/");
+            fail("IllegalArgumentException should be thrown");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Unsupported namespace URI"));
+        }
+        assertThat(
+                S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefixes("http://www.w3.org/2000/xmlns/").hasNext(),
+                is(false)
+        );
     }
 
     private static final class TestWebDriverManager extends WebDriverManager {

--- a/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
@@ -1,0 +1,99 @@
+package io.github.bonigarcia.wdm.test.other;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import io.github.bonigarcia.wdm.config.DriverManagerType;
+import io.github.bonigarcia.wdm.online.HttpClient;
+import io.github.bonigarcia.wdm.online.S3BucketListNamespaceContext;
+import org.junit.Test;
+
+import javax.xml.namespace.NamespaceContext;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+public class NamespaceContextTest {
+
+    @Test
+    public void testS3BucketListNamespaceContext() throws IOException {
+        TestWebDriverManager testManager = new TestWebDriverManager();
+        List<URL> urls = testManager.getDriverUrls();
+        assertThat(urls, is(not(empty())));
+    }
+
+    private static final class TestWebDriverManager extends WebDriverManager{
+
+        @Override
+        protected NamespaceContext getNamespaceContext() {
+            return new S3BucketListNamespaceContext();
+        }
+
+        @Override
+        protected List<URL> getDriverUrls() throws IOException {
+            httpClient = new HttpClient(config());
+            return getDriversFromXml(getDriverUrl(), "//s3:Contents/s3:Key");
+        }
+
+        @Override
+        protected Optional<String> getBrowserVersionFromTheShell() {
+            return Optional.empty();
+        }
+
+        @Override
+        protected String getDriverName() {
+            return null;
+        }
+
+        @Override
+        protected String getDriverVersion() {
+            return null;
+        }
+
+        @Override
+        protected void setDriverVersion(String driverVersion) {
+
+        }
+
+        @Override
+        protected String getBrowserVersion() {
+            return null;
+        }
+
+        @Override
+        protected void setBrowserVersion(String browserVersion) {
+
+        }
+
+        @Override
+        protected void setDriverUrl(URL url) {
+
+        }
+
+        @Override
+        protected URL getDriverUrl() {
+            return getDriverUrlCkeckingMirror(config().getChromeDriverUrl());
+        }
+
+        @Override
+        protected Optional<URL> getMirrorUrl() {
+            return Optional.empty();
+        }
+
+        @Override
+        protected Optional<String> getExportParameter() {
+            return Optional.empty();
+        }
+
+        @Override
+        public DriverManagerType getDriverManagerType() {
+            return null;
+        }
+
+    }
+
+}

--- a/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/other/NamespaceContextTest.java
@@ -4,6 +4,7 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
 import io.github.bonigarcia.wdm.online.HttpClient;
 import io.github.bonigarcia.wdm.online.S3BucketListNamespaceContext;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import javax.xml.namespace.NamespaceContext;
@@ -11,11 +12,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.fail;
@@ -34,7 +35,7 @@ public class NamespaceContextTest {
     }
 
     @Test
-    public void testS3BucketListNamespaceContextPrefixes(){
+    public void testS3BucketListNamespaceContextPrefixes() {
         assertThat(S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getNamespaceURI("s3"), equalTo(S3_URI));
         assertThat(S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefix(S3_URI), equalTo("s3"));
         Iterator<String> prefixes = S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getPrefixes(S3_URI);
@@ -44,7 +45,7 @@ public class NamespaceContextTest {
 
 
     @Test
-    public void testS3BucketListNamespaceContextInvalidPrefixes(){
+    public void testS3BucketListNamespaceContextInvalidPrefixes() {
         try {
             S_3_BUCKET_LIST_NAMESPACE_CONTEXT.getNamespaceURI("xmlns");
             fail("IllegalArgumentException should be thrown");
@@ -107,13 +108,13 @@ public class NamespaceContextTest {
         }
 
         @Override
-        protected void setDriverUrl(URL url) {
-
+        protected URL getDriverUrl() {
+            return getDriverUrlCkeckingMirror(config().getChromeDriverUrl());
         }
 
         @Override
-        protected URL getDriverUrl() {
-            return getDriverUrlCkeckingMirror(config().getChromeDriverUrl());
+        protected void setDriverUrl(URL url) {
+
         }
 
         @Override


### PR DESCRIPTION
A fix for https://github.com/bonigarcia/webdrivermanager/issues/486

### Purpose of changes
The WebdriverManager has recently stopped working with Saxon. This change adds namespace context to make it work with Saxon xPath factory.

### Types of changes
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I created a custom build for our test suite to make it work. It works in our teamcity.
