### PR TITLE
Fix flaky test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,17 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+         <dependency>
+            <groupId>org.mockito</groupId>
+           <artifactId>mockito-core</artifactId>
+            <version>3.5.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.27.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
          <dependency>
             <groupId>org.mockito</groupId>
-           <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>3.5.10</version>
         </dependency>
         <dependency>

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -61,7 +61,7 @@ public class VersionsTest {
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-        return asList(new Object[][] { 
+         return asList(new Object[][] { 
             { chromedriver() }, { firefoxdriver() },
                 { operadriver() }, { edgedriver() }, { iedriver() },
                 { phantomjs() } });

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 
-
 /**
  * Test getting all versions.
  *
@@ -62,7 +61,7 @@ public class VersionsTest {
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-       return asList(new Object[][] {
+       return asList(new Object[][] { 
             { chromedriver() }, { firefoxdriver() },
                 { operadriver() }, { edgedriver() }, { iedriver() },
                 { phantomjs() } });

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -61,7 +61,7 @@ public class VersionsTest {
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-       return asList(new Object[][] { 
+        return asList(new Object[][] { 
             { chromedriver() }, { firefoxdriver() },
                 { operadriver() }, { edgedriver() }, { iedriver() },
                 { phantomjs() } });

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -24,15 +24,14 @@ import static io.github.bonigarcia.wdm.WebDriverManager.operadriver;
 import static io.github.bonigarcia.wdm.WebDriverManager.phantomjs;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import java.util.Collection;
 import java.util.List;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,18 +68,19 @@ public class VersionsTest {
 
     @Test
      public void testChromeDriverVersions() {
-        // Mock gihub response for gecko driver and opera driver
-        stubFor(get(urlEqualTo("api.github.com/repos/mozilla/geckodriver/releases"))
+        // Mock gihub response for gecko driver and opera driver 
+        WireMockServer wm = new WireMockServer(options().port(8888));
+        wm.stubFor(get(urlEqualTo("api.github.com/repos/mozilla/geckodriver/releases"))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "text/plain")
                 .withBody("Mock Content")));
-        stubFor(get(urlEqualTo("api.github.com/repos/operasoftware/operachromiumdriver/releases"))
+        wm.stubFor(get(urlEqualTo("api.github.com/repos/operasoftware/operachromiumdriver/releases"))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "text/plain")
                 .withBody("Mock Content")));
-         List<String> versions = driverManager.getDriverVersions();
-         log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
-                 versions);
+            List<String> versions = driverManager.getDriverVersions();
+            log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
+                    versions);
      }
 
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -61,7 +61,7 @@ public class VersionsTest {
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-         return asList(new Object[][] { 
+        return asList(new Object[][] { 
             { chromedriver() }, { firefoxdriver() },
                 { operadriver() }, { edgedriver() }, { iedriver() },
                 { phantomjs() } });

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -24,6 +24,10 @@ import static io.github.bonigarcia.wdm.WebDriverManager.operadriver;
 import static io.github.bonigarcia.wdm.WebDriverManager.phantomjs;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Collection;
@@ -32,7 +36,6 @@ import java.util.List;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -59,7 +62,7 @@ public class VersionsTest {
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-        return asList(new Object[][] { 
+        return asList(new Object[][] {
             { chromedriver() }, { firefoxdriver() },
                 { operadriver() }, { edgedriver() }, { iedriver() },
                 { phantomjs() } });
@@ -68,19 +71,21 @@ public class VersionsTest {
 
     @Test
      public void testChromeDriverVersions() {
-        // Mock gihub response for gecko driver and opera driver 
+        // Mock gihub response for gecko driver and opera driver
         WireMockServer wm = new WireMockServer(options().port(8888));
         wm.stubFor(get(urlEqualTo("api.github.com/repos/mozilla/geckodriver/releases"))
-            .willReturn(aResponse()
-                .withHeader("Content-Type", "text/plain")
-                .withBody("Mock Content")));
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Mock Content")));
         wm.stubFor(get(urlEqualTo("api.github.com/repos/operasoftware/operachromiumdriver/releases"))
-            .willReturn(aResponse()
-                .withHeader("Content-Type", "text/plain")
-                .withBody("Mock Content")));
-            List<String> versions = driverManager.getDriverVersions();
-            log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
-                    versions);
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Mock Content")));
+        List<String> versions = driverManager.getDriverVersions();
+        log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
+                versions);
+        assertThat(versions, notNullValue());
+        assertThat(versions, not(empty()));
      }
 
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -62,7 +62,7 @@ public class VersionsTest {
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-        return asList(new Object[][] {
+       return asList(new Object[][] {
             { chromedriver() }, { firefoxdriver() },
                 { operadriver() }, { edgedriver() }, { iedriver() },
                 { phantomjs() } });
@@ -70,22 +70,22 @@ public class VersionsTest {
     }
 
     @Test
-     public void testChromeDriverVersions() {
-        // Mock gihub response for gecko driver and opera driver
-        WireMockServer wm = new WireMockServer(options().port(8888));
-        wm.stubFor(get(urlEqualTo("api.github.com/repos/mozilla/geckodriver/releases"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody("Mock Content")));
-        wm.stubFor(get(urlEqualTo("api.github.com/repos/operasoftware/operachromiumdriver/releases"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody("Mock Content")));
-        List<String> versions = driverManager.getDriverVersions();
-        log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
-                versions);
-        assertThat(versions, notNullValue());
-        assertThat(versions, not(empty()));
+    public void testChromeDriverVersions() {
+       // Mock gihub response for gecko driver and opera driver
+       WireMockServer wm = new WireMockServer(options().port(8888));
+       wm.stubFor(get(urlEqualTo("api.github.com/repos/mozilla/geckodriver/releases"))
+               .willReturn(aResponse()
+                       .withHeader("Content-Type", "text/plain")
+                       .withBody("Mock Content")));
+       wm.stubFor(get(urlEqualTo("api.github.com/repos/operasoftware/operachromiumdriver/releases"))
+               .willReturn(aResponse()
+                       .withHeader("Content-Type", "text/plain")
+                       .withBody("Mock Content")));
+       List<String> versions = driverManager.getDriverVersions();
+       log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
+               versions);
+       assertThat(versions, notNullValue());
+       assertThat(versions, not(empty()));
      }
 
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/versions/VersionsTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
+
 
 /**
  * Test getting all versions.
@@ -66,12 +68,19 @@ public class VersionsTest {
     }
 
     @Test
-    public void testChromeDriverVersions() {
-        List<String> versions = driverManager.getDriverVersions();
-        log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
-                versions);
-        assertThat(versions, notNullValue());
-        assertThat(versions, not(empty()));
-    }
+     public void testChromeDriverVersions() {
+        // Mock gihub response for gecko driver and opera driver
+        stubFor(get(urlEqualTo("api.github.com/repos/mozilla/geckodriver/releases"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "text/plain")
+                .withBody("Mock Content")));
+        stubFor(get(urlEqualTo("api.github.com/repos/operasoftware/operachromiumdriver/releases"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "text/plain")
+                .withBody("Mock Content")));
+         List<String> versions = driverManager.getDriverVersions();
+         log.debug("Versions of {} {}", driverManager.getClass().getSimpleName(),
+                 versions);
+     }
 
 }


### PR DESCRIPTION
The test
`io.github.bonigarcia.wdm.test.versions.VersionsTest.testChromeDriverVersions`
is flaky and the goal is to remove that flakiness.

Flaky Test Reason:
`WebDriverManager`was trying to get drivers from Github using the driver URL. GitHub servers will return an HTTP 403 error when several consecutive requests are made by WebDriverManager. Unfortunately, this is what happened in VersionsTest: since in this test we are testing driver versions for different web drivers/browsers, we need to get the latest drivers for all of them. Since some of the drivers (geckodriver and operadriver) are hosted on GitHub, we are sending several consecutive requests to the GitHub servers when we're running this test, which results in some requests being rejected (HTTP 403) by the GitHub servers, and therefore the flaky tests. This is also a known issue to this project (see Known Issue).

Types of changes
Using WireMock to Mock the server and test the HTTP request, thus the request will not be rejected anymore.