### PR TITLE
Makes dependabot update the github actions version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     interval: daily
     time: '06:00'
   open-pull-requests-limit: 99
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '06:00'
+  open-pull-requests-limit: 99


### PR DESCRIPTION
### Purpose of changes

Makes @dependabot scans the build pipeline searching for Github Actions that are not up to date.

### Types of changes

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?

By updating a local branch my fork receives PRs