### PR TITLE
Issue #740 Allow using private docker registry as mirror with authent…

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/config/Config.java
@@ -255,6 +255,15 @@ public class Config {
     ConfigKey<Boolean> dockerLocalFallback = new ConfigKey<>(
             "wdm.dockerLocalFallback", Boolean.class);
 
+    ConfigKey<String> dockerPrivateEndpoint = new ConfigKey<>(
+            "wdm.dockerPrivateEndpoint", String.class);
+
+    ConfigKey<String> dockerPrivateUsername = new ConfigKey<>(
+            "wdm.dockerPrivateUsername", String.class);
+
+    ConfigKey<String> dockerPrivatePassword = new ConfigKey<>(
+            "wdm.dockerPrivatePassword", String.class);
+
     ConfigKey<String> remoteAddress = new ConfigKey<>("wdm.remoteAddress",
             String.class);
 
@@ -1325,6 +1334,34 @@ public class Config {
         this.dockerLocalFallback.setValue(value);
         return this;
     }
+
+    public String getDockerPrivateEndpoint() {
+        return resolve(dockerPrivateEndpoint);
+    }
+
+    public Config setDockerPrivateEndpoint(String value) {
+        this.dockerPrivateEndpoint.setValue(value);
+        return this;
+    }
+
+    public String getDockerPrivateUsername() {
+        return resolve(dockerPrivateUsername);
+    }
+
+    public Config setDockerPrivateUsername(String value) {
+        this.dockerPrivateUsername.setValue(value);
+        return this;
+    }
+
+    public String getDockerPrivatePassword() {
+        return resolve(dockerPrivatePassword);
+    }
+
+    public Config setDockerPrivatePassword(String value) {
+        this.dockerPrivatePassword.setValue(value);
+        return this;
+    }
+
 
     public String getRemoteAddress() {
         return resolve(remoteAddress);


### PR DESCRIPTION
### Purpose of changes
Allow to use private registry with authentication to pull docker images from it.

### Types of changes
Adding configuration parameters to define the private registry endpoint, as well as the authentication credentials if required.

- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Manually with our private docker registry, also on macbook since docker uses osxkeychain by default to store the auth information, username and password need to be provided even if docker login was performed earlier.
