### PR TITLE
Issue #740 Allow using private docker registry as mirror with authent…

### DIFF
--- a/src/doc/asciidoc/index.adoc
+++ b/src/doc/asciidoc/index.adoc
@@ -631,6 +631,7 @@ HTTP proxy. It can be also configured using the environment variable  `HTTPS_PRO
 |`dockerRecordingPrefix(String)`|`wdm.dockerRecordingPrefix`|Browser name|Prefix to be appended to default filname (i.e., broser name plus `_` plus session id)
 |`dockerCustomImage(String)`|`wdm.dockerCustomImage`|`""`|Custom image to be used as browser in Docker
 | `dockerVolume(String)` `dockerVolumes(String[])`|`wdm.dockerVolumes`|`""`|Docker volumes (single or array) using the format `"\local\path:\container\path"`
+| `dockerPrivateEndpoint(String)`|`wdm.dockerPrivateEndpoint`|`""`|Used to prefix pull images when you have a private registry with authentication i.e docker-hub-remote.myprivate.com will be prefixed to pull as docker-hub-remote.myprivate.com/selenoid/vnc and so on for any images used (video recorder, novnc etc..), docker login docker-hub-remote.myprivate.com is still required in order to get the auth credentials stored in the .docker/config.json, for MacOS users make sure to configure your engine to store the credentials in the config.json instead of keychain storage.
 |=======
 
 [[server_config]]

--- a/src/main/java/io/github/bonigarcia/wdm/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/config/Config.java
@@ -255,6 +255,9 @@ public class Config {
     ConfigKey<Boolean> dockerLocalFallback = new ConfigKey<>(
             "wdm.dockerLocalFallback", Boolean.class);
 
+    ConfigKey<String> dockerPrivateEndpoint = new ConfigKey<>(
+            "wdm.dockerPrivateEndpoint", String.class);
+
     ConfigKey<String> remoteAddress = new ConfigKey<>("wdm.remoteAddress",
             String.class);
 
@@ -1323,6 +1326,15 @@ public class Config {
 
     public Config setDockerLocalFallback(boolean value) {
         this.dockerLocalFallback.setValue(value);
+        return this;
+    }
+
+    public String getDockerPrivateEndpoint() {
+        return resolve(dockerPrivateEndpoint);
+    }
+
+    public Config setDockerPrivateEndpoint(String value) {
+        this.dockerPrivateEndpoint.setValue(value);
         return this;
     }
 

--- a/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
+++ b/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
@@ -37,9 +37,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.github.dockerjava.api.model.AuthConfig;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 
 import com.github.dockerjava.api.DockerClient;
@@ -509,9 +512,19 @@ public class DockerService {
         return browserVersion.toLowerCase(ROOT).contains(LATEST_MINUS);
     }
 
+    private String getPrefixedDockerImage(String dockerImage) {
+        String newDockerImage = dockerImage;
+        String prefix = config.getDockerPrivateEndpoint();
+        if (StringUtils.isNotBlank(prefix)) {
+            newDockerImage = String.format("%s/%s", prefix, dockerImage);
+        }
+        return newDockerImage;
+    }
+
     public DockerContainer startNoVncContainer(String dockerImage,
             String cacheKey, String browserVersion,
             DockerContainer browserContainer) {
+        dockerImage = getPrefixedDockerImage(dockerImage);
         // pull image
         pullImageIfNecessary(cacheKey, dockerImage, browserVersion);
 
@@ -551,6 +564,7 @@ public class DockerService {
 
     public DockerContainer startBrowserContainer(String dockerImage,
             String cacheKey, String browserVersion, boolean androidEnabled) {
+        dockerImage = getPrefixedDockerImage(dockerImage);
         // pull image
         pullImageIfNecessary(cacheKey, dockerImage, browserVersion);
 
@@ -645,6 +659,7 @@ public class DockerService {
     public DockerContainer startRecorderContainer(String dockerImage,
             String cacheKey, String recorderVersion,
             DockerContainer browserContainer) {
+        dockerImage = getPrefixedDockerImage(dockerImage);
         // pull image
         pullImageIfNecessary(cacheKey, dockerImage, recorderVersion);
 


### PR DESCRIPTION
### Purpose of changes
Allow to use private registry to pull docker images from it.

### Types of changes
Adding configuration parameters to define the private registry endpoint.

- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Manually mainly as docker login need to be performed to that endpoint which cannot be a localhost based (otherwise it would need also to change docker daemon config to allow insecure registry etc..), Note that on macos, auth is not stored in the .docker/config.json but inside osxkeychain which need to be turned off.