### PR TITLE
Enable volume/bind mounts on the browser container

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
+++ b/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
@@ -559,7 +559,6 @@ public class DockerService {
         String dockerBrowserPort = String
                 .valueOf(config.getDockerBrowserPort());
         exposedPorts.add(dockerBrowserPort);
-        exposedPorts.add("8080");
 
         // shmSize
         long shmSize = config.getDockerMemSizeBytes(config.getDockerShmSize());

--- a/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
+++ b/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
@@ -559,6 +559,7 @@ public class DockerService {
         String dockerBrowserPort = String
                 .valueOf(config.getDockerBrowserPort());
         exposedPorts.add(dockerBrowserPort);
+        exposedPorts.add("8080");
 
         // shmSize
         long shmSize = config.getDockerMemSizeBytes(config.getDockerShmSize());
@@ -570,6 +571,15 @@ public class DockerService {
                         .getDockerMemSizeBytes(config.getDockerTmpfsSize())))
                 .withTarget(config.getDockerTmpfsMount());
         mounts.add(tmpfsMount);
+
+        // binds
+        List<String> binds = new ArrayList<>();
+        String dockerVolumes = config.getDockerVolumes();
+        if (!isNullOrEmpty(dockerVolumes)) {
+            List<String> volumeList = Arrays.asList(dockerVolumes.split(","));
+            log.trace("Using custom volumes: {}", volumeList);
+            binds.addAll(volumeList);
+        }
 
         // envs
         List<String> envs = new ArrayList<>();
@@ -596,7 +606,7 @@ public class DockerService {
         // builder
         DockerBuilder dockerBuilder = DockerContainer.dockerBuilder(dockerImage)
                 .exposedPorts(exposedPorts).network(network).mounts(mounts)
-                .shmSize(shmSize).envs(envs).sysadmin();
+                .binds(binds).shmSize(shmSize).envs(envs).sysadmin();
         if (androidEnabled) {
             dockerBuilder = dockerBuilder.privileged();
         }


### PR DESCRIPTION
### Purpose of changes
This PR enables users to map docker volumes on the browser container. Currently this is only supported on the recorder container.

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Verified that bind mounts are applied correctly. This functionality is basicly copy-paste of the functionality on the recorder container.
