### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
     - name: Start Xvfb
       run: Xvfb :99 &


### PR DESCRIPTION
Changed the distribution from `adopt` to `zulu` for GitHub actions.

### Purpose of changes
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.


### Types of changes
<!-- Put an `x` in the boxes that apply -->
- [x] CI/CD update to use a TCK tested JDK and obtain the latest builds of the openjdk as a distribution.

### How has this been tested?
n/a The GitHub actions workflow jobs should pass. 