### PR TITLE
Docker extra hosts

### DIFF
--- a/src/doc/asciidoc/index.adoc
+++ b/src/doc/asciidoc/index.adoc
@@ -639,6 +639,7 @@ HTTP proxy. It can be also configured using the environment variable  `HTTPS_PRO
 |`dockerRecordingPrefix(String)`|`wdm.dockerRecordingPrefix`|Browser name|Prefix to be appended to default filname (i.e., broser name plus `_` plus session id)
 |`dockerCustomImage(String)`|`wdm.dockerCustomImage`|`""`|Custom image to be used as browser in Docker
 |`dockerVolumes(String[])`|`wdm.dockerVolumes`|`""`|Docker volumes (single or array) using the format `"\local\path:\container\path"`
+|`dockerExtraHosts(String[])`|`wdm.dockerExtraHosts`|`""`|Docker Extra Hosts (single or array) using the format `"hostname:IP" ("some-host:162.242.195.82")`
 |`dockerPrivateEndpoint(String)`|`wdm.dockerPrivateEndpoint`|`""`|Used to prefix pull images when you have a private registry with authentication i.e docker-hub-remote.myprivate.com will be prefixed to pull as docker-hub-remote.myprivate.com/selenoid/vnc and so on for any images used (video recorder, novnc etc..), docker login docker-hub-remote.myprivate.com is still required in order to get the auth credentials stored in the .docker/config.json, for MacOS users make sure to configure your engine to store the credentials in the config.json instead of keychain storage.
 |=======
 

--- a/src/doc/asciidoc/index.adoc
+++ b/src/doc/asciidoc/index.adoc
@@ -639,7 +639,7 @@ HTTP proxy. It can be also configured using the environment variable  `HTTPS_PRO
 |`dockerRecordingPrefix(String)`|`wdm.dockerRecordingPrefix`|Browser name|Prefix to be appended to default filname (i.e., broser name plus `_` plus session id)
 |`dockerCustomImage(String)`|`wdm.dockerCustomImage`|`""`|Custom image to be used as browser in Docker
 |`dockerVolumes(String[])`|`wdm.dockerVolumes`|`""`|Docker volumes (single or array) using the format `"\local\path:\container\path"`
-|`dockerExtraHosts(String[])`|`wdm.dockerExtraHosts`|`""`|Docker Extra Hosts (single or array) using the format `"hostname:IP" ("some-host:162.242.195.82")`
+|`dockerExtraHosts(String[])`|`wdm.dockerExtraHosts`|`""`|Docker Extra Hosts (single or array) using the format `"hostname:IP" ("host1:192.168.48.82,host2:192.168.48.16")`
 |`dockerPrivateEndpoint(String)`|`wdm.dockerPrivateEndpoint`|`""`|Used to prefix pull images when you have a private registry with authentication i.e docker-hub-remote.myprivate.com will be prefixed to pull as docker-hub-remote.myprivate.com/selenoid/vnc and so on for any images used (video recorder, novnc etc..), docker login docker-hub-remote.myprivate.com is still required in order to get the auth credentials stored in the .docker/config.json, for MacOS users make sure to configure your engine to store the credentials in the config.json instead of keychain storage.
 |=======
 

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -471,6 +471,11 @@ public abstract class WebDriverManager {
         return this;
     }
 
+    public WebDriverManager dockerExtraHosts(String... hosts) {
+        config().setDockerExtraHosts(String.join(",", hosts));
+        return this;
+    }
+
     public WebDriverManager dockerScreenResolution(String screenResolution) {
         config().setDockerScreenResolution(screenResolution);
         return this;

--- a/src/main/java/io/github/bonigarcia/wdm/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/config/Config.java
@@ -248,6 +248,8 @@ public class Config {
             "wdm.dockerCustomImage", String.class);
     ConfigKey<String> dockerVolumes = new ConfigKey<>("wdm.dockerVolumes",
             String.class);
+    ConfigKey<String> dockerExtraHosts = new ConfigKey<>("wdm.dockerExtraHosts",
+            String.class);
     ConfigKey<String> dockerEnvVariables = new ConfigKey<>(
             "wdm.dockerEnvVariables", String.class);
     ConfigKey<String> dockerDefaultArgs = new ConfigKey<>(
@@ -1382,6 +1384,20 @@ public class Config {
 
     public Config setDockerVolumes(String... value) {
         this.dockerVolumes.setValue(join(":", value));
+        return this;
+    }
+
+    public List<String> getDockerExtraHosts() {
+        String extraHosts = resolve(dockerExtraHosts);
+        String[] out = {};
+        if (!isNullOrEmpty(extraHosts)) {
+            out = extraHosts.split(",");
+        }
+        return Arrays.asList(out);
+    }
+
+    public Config setDockerExtraHosts(String... value) {
+        this.dockerExtraHosts.setValue(join(",", value));
         return this;
     }
 

--- a/src/main/java/io/github/bonigarcia/wdm/docker/DockerContainer.java
+++ b/src/main/java/io/github/bonigarcia/wdm/docker/DockerContainer.java
@@ -21,6 +21,7 @@ import static java.util.Optional.of;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -37,6 +38,7 @@ import com.github.dockerjava.api.model.Mount;
 public class DockerContainer {
 
     private List<String> exposedPorts;
+    private List<String> extraHosts;
     private String imageId;
     private Optional<List<Bind>> binds;
     private Optional<List<String>> envs;
@@ -61,6 +63,7 @@ public class DockerContainer {
         this.imageId = builder.imageId;
         this.exposedPorts = builder.exposedPorts != null ? builder.exposedPorts
                 : new ArrayList<>();
+        this.extraHosts = builder.extraHosts != null ? builder.extraHosts : new ArrayList<>();
         this.binds = builder.binds != null ? of(builder.binds) : empty();
         this.envs = builder.envs != null ? of(builder.envs) : empty();
         this.network = builder.network != null ? of(builder.network) : empty();
@@ -91,6 +94,10 @@ public class DockerContainer {
 
     public List<String> getExposedPorts() {
         return exposedPorts;
+    }
+
+    public String[] getExtraHosts() {
+        return Arrays.copyOf(extraHosts.toArray(), extraHosts.size(), String[].class);
     }
 
     public Optional<String> getNetwork() {
@@ -205,6 +212,7 @@ public class DockerContainer {
         private boolean privileged = false;
         private boolean sysadmin = false;
         private List<String> exposedPorts;
+        private List<String> extraHosts;
 
         public DockerBuilder(String imageId) {
             this.imageId = imageId;
@@ -212,6 +220,11 @@ public class DockerContainer {
 
         public DockerBuilder exposedPorts(List<String> ports) {
             this.exposedPorts = ports;
+            return this;
+        }
+
+        public DockerBuilder extraHosts(List<String> extraHosts) {
+            this.extraHosts = extraHosts;
             return this;
         }
 

--- a/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
+++ b/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
@@ -172,7 +172,7 @@ public class DockerService {
         String imageId = dockerContainer.getImageId();
         log.info("Starting Docker container {}", imageId);
         HostConfig hostConfigBuilder = new HostConfig();
-        String containerId = null;
+        String containerId;
 
         try (CreateContainerCmd containerConfigBuilder = dockerClient
                 .createContainerCmd(imageId)) {
@@ -236,8 +236,12 @@ public class DockerService {
                         entryPoint.get().toArray(new String[] {}));
             }
 
+            hostConfigBuilder.withExtraHosts(dockerContainer.getExtraHosts());
+
             containerId = containerConfigBuilder
-                    .withHostConfig(hostConfigBuilder).exec().getId();
+                    .withHostConfig(hostConfigBuilder)
+                    .exec().getId();
+
             dockerClient.startContainerCmd(containerId).exec();
         }
 
@@ -551,10 +555,13 @@ public class DockerService {
         // network
         String network = config.getDockerNetwork();
 
+        // extra hosts
+        List<String> extraHosts = config.getDockerExtraHosts();
+
         // builder
         DockerContainer noVncContainer = DockerContainer
                 .dockerBuilder(dockerImage).exposedPorts(exposedPorts)
-                .network(network).envs(envs).build();
+                .network(network).extraHosts(extraHosts).envs(envs).build();
 
         String containerId = startContainer(noVncContainer);
 
@@ -622,10 +629,13 @@ public class DockerService {
         // network
         String network = config.getDockerNetwork();
 
+        // extra hosts
+        List<String> extraHosts = config.getDockerExtraHosts();
+
         // builder
         DockerBuilder dockerBuilder = DockerContainer.dockerBuilder(dockerImage)
                 .exposedPorts(exposedPorts).network(network).mounts(mounts)
-                .binds(binds).shmSize(shmSize).envs(envs).sysadmin();
+                .binds(binds).shmSize(shmSize).envs(envs).extraHosts(extraHosts).sysadmin();
         if (androidEnabled) {
             dockerBuilder = dockerBuilder.privileged();
         }
@@ -689,6 +699,9 @@ public class DockerService {
         // network
         String network = config.getDockerNetwork();
 
+        // extra hosts
+        List<String> extraHosts = config.getDockerExtraHosts();
+
         // binds
         List<String> binds = new ArrayList<>();
         binds.add(recordingPath.toAbsolutePath().getParent().toString()
@@ -703,7 +716,7 @@ public class DockerService {
         // builder
         DockerContainer recorderContainer = DockerContainer
                 .dockerBuilder(dockerImage).network(network).envs(envs)
-                .binds(binds).sysadmin().build();
+                .binds(binds).extraHosts(extraHosts).sysadmin().build();
 
         String containerId = startContainer(recorderContainer);
         recorderContainer.setContainerId(containerId);

--- a/src/test/java/io/github/bonigarcia/wdm/test/properties/PropertiesTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/properties/PropertiesTest.java
@@ -206,6 +206,7 @@ class PropertiesTest {
         assertThat(config.getDockerVolumes()).isEmpty();
         assertThat(config.getDockerEnvVariables()).isEmpty();
         assertThat(config.getDockerPrivateEndpoint()).isEmpty();
+        assertThat(config.getDockerExtraHosts()).isEmpty();
     }
 
     @Test
@@ -514,5 +515,8 @@ class PropertiesTest {
 
         config.setDockerPrivateEndpoint(CUSTOM_VALUE);
         assertThat(config.getDockerPrivateEndpoint()).isEqualTo(CUSTOM_VALUE);
+
+        config.setDockerPrivateEndpoint("host1:192.168.48.82,host2:192.168.48.16");
+        assertThat(config.getDockerPrivateEndpoint()).isEqualTo("host1:192.168.48.82,host2:192.168.48.16");
     }
 }


### PR DESCRIPTION
### Purpose of changes
Sometime in a CI context the docker on the CI runner don't have all expected hosts configuration.
By adding Docker ExtraHosts config support we can fix this issue.

### Types of changes
Adding Docker ExtraHosts config to WebDriverManager Docker config