### PR TITLE
[#795] Fixed lazy instantiation for some fields of `WebDriverManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.1.1] - 2022-xx-xx
+
+### Fixed
+- detection for snap installed browser (issue #795)
+
 ## [5.1.0] - 2022-02-17
 ### Added
 - Add Docker Extra Hosts API method: dockerExtraHosts(String[]) (PR #788)

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -1487,17 +1487,26 @@ public abstract class WebDriverManager {
 
     protected ResolutionCache getResolutionCache() {
         return Optional.ofNullable(resolutionCache)
-                .orElse(new ResolutionCache(config()));
+                .orElseGet(() -> {
+                    resolutionCache = new ResolutionCache(config());
+                    return resolutionCache;
+                });
     }
 
     protected VersionDetector getVersionDetector() {
         return Optional.ofNullable(versionDetector)
-                .orElse(new VersionDetector(config(), getHttpClient()));
+                .orElseGet(() -> {
+                    versionDetector = new VersionDetector(config(), getHttpClient());
+                    return versionDetector;
+                });
     }
 
     protected WebDriverCreator getWebDriverCreator() {
         return Optional.ofNullable(webDriverCreator)
-                .orElse(new WebDriverCreator(config()));
+                .orElseGet(() -> {
+                    webDriverCreator = new WebDriverCreator(config());
+                    return webDriverCreator;
+                });
     }
 
     protected FilenameFilter getFolderFilter() {


### PR DESCRIPTION
### Purpose of changes
fix for issue #795

### Types of changes
Fixed lazy instantiation for fields `resolutionCache`, `versionDetector` and `webDriverCreator` of `WebDriverManager`.

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
New version was build locally and included to an using project.

`WebDriverManager.chromiumdriver().setup()` now produces the log output:

> [DEBUG] Detecting chromium version using online commands.properties
> [DEBUG] Running command on the shell: [chromium-browser, --version]
> [DEBUG] Result: Chromium 98.0.4758.102 snap
> [DEBUG] Latest version of chromedriver according to https://chromedriver.storage.googleapis.com/LATEST_RELEASE_98 is 98.0.4758.102
> [INFO] Using chromedriver 98.0.4758.102 (resolved driver for Chromium 98)
> [DEBUG] Found CHROMIUM snap
> [INFO] Exporting webdriver.chrome.driver as /snap/bin/chromium.chromedriver

instead of downloading a chromedriver.

> **Notes:**
> - Nevertheless due to [Selenium issue 7788](https://github.com/SeleniumHQ/selenium/issues/7788) starting the snap installed chromedriver does not work on e.g. Ubuntu 20.04. But the workaround described there does the job.
> - `mvn verify` executed for this fixed version continues complaining about 10 failing tests when executed on Ubuntu 20.04 with snap installed `chromium` and `chromium.chromedriver` but no installation of `google-chrome` (same as without the fix). These are related to `WebDriverManager.chromedriver().setup()` which cannot detect a `google-chrome` but downloads and starts a chromedriver which finally starts a chromium but cannot control it.