### PR TITLE
Normalize path separators in WebDriverManager.zipFolder()

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -44,6 +44,7 @@ import static javax.xml.xpath.XPathConstants.NODESET;
 import static javax.xml.xpath.XPathFactory.newInstance;
 import static org.apache.commons.io.FileUtils.cleanDirectory;
 import static org.apache.commons.io.FilenameUtils.removeExtension;
+import static org.apache.commons.io.FilenameUtils.separatorsToUnix;
 import static org.apache.commons.lang3.StringUtils.isNumeric;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_LINUX;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -334,7 +335,7 @@ public abstract class WebDriverManager {
                     Stream<Path> paths = Files.walk(sourceFolder)) {
                 paths.filter(path -> !Files.isDirectory(path)).forEach(path -> {
                     ZipEntry zipEntry = new ZipEntry(
-                            sourceFolder.relativize(path).toString());
+                            separatorsToUnix(sourceFolder.relativize(path).toString()));
                     try {
                         zipOutputStream.putNextEntry(zipEntry);
                         Files.copy(path, zipOutputStream);


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
The ZIP file format mandates the use of Unix-style path separators.

See https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

Possible fix for the issue reported in this comment: https://github.com/SeleniumHQ/selenium/issues/8357#issuecomment-1091248814

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Sorry, didn't have time to write a proper unit test.
