### PR TITLE
Don't swallow exception root cause when creating a RemoteWebDriver

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/webdriver/WebDriverCreator.java
+++ b/src/main/java/io/github/bonigarcia/wdm/webdriver/WebDriverCreator.java
@@ -94,7 +94,7 @@ public class WebDriverCreator {
                     if (System.currentTimeMillis() > timeoutMs) {
                         throw new WebDriverManagerException(
                                 "Timeout of " + waitTimeoutSec
-                                        + " seconds creating WebDriver object");
+                                        + " seconds creating WebDriver object", e1);
                     }
                     Thread.sleep(TimeUnit.SECONDS.toMillis(POLL_TIME_SEC));
                 } catch (InterruptedException e2) {


### PR DESCRIPTION
### Purpose of changes

Currently, the (last) root cause for a failing connection to a remote Selenium Grid is swallowed. the root cause is only visible if someone enables `trace` level logging.

I ran into this issue because I was having SSL handshake issues with an Selenium Grid and the exception just told me `Timeout of 30 seconds creating WebDriver object`.

```
[INFO] Running myproject.ui.LoginTest
2022-07-27 15:29:16.902 DEBUG   --- [           main] i.g.b.wdm.webdriver.WebDriverCreator     : Creating WebDriver object for firefox at https://myseleniumgrid.com/wd/hub with Capabilities {acceptInsecureCerts: true, browserName: firefox, moz:debuggerAddress: true, moz:firefoxOptions: {args: [--headless]}}

[...]

// the root cause (level trace)

2022-07-27 15:29:17.069 TRACE   --- [           main] i.g.b.wdm.webdriver.WebDriverCreator     : SSLHandshakeException creating WebDriver object (PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target)
 [...] 

// the reported cause (no mention of the root cause)

2022-07-27 15:29:47.626 ERROR   --- [           main] i.g.bonigarcia.wdm.WebDriverManager      : There was an error creating WebDriver object for Firefox
io.github.bonigarcia.wdm.config.WebDriverManagerException: Timeout of 30 seconds creating WebDriver object
	at io.github.bonigarcia.wdm.webdriver.WebDriverCreator.createRemoteWebDriver(WebDriverCreator.java:95)
	at io.github.bonigarcia.wdm.WebDriverManager.instantiateDriver(WebDriverManager.java:1742)
[ no root cause in stacktrace included ]
```



### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?

None because the change is minimal.
