### PR TITLE
Fix/#897 fix edgedriver on mac m1

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/managers/EdgeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/EdgeDriverManager.java
@@ -18,6 +18,7 @@ package io.github.bonigarcia.wdm.managers;
 
 import static io.github.bonigarcia.wdm.config.Architecture.ARM64;
 import static io.github.bonigarcia.wdm.config.DriverManagerType.EDGE;
+import static io.github.bonigarcia.wdm.config.OperatingSystem.MAC;
 import static java.util.Locale.ROOT;
 import static java.util.Optional.empty;
 import static org.apache.commons.io.FileUtils.listFiles;
@@ -191,8 +192,10 @@ public class EdgeDriverManager extends WebDriverManager {
             Architecture arch = config.getArchitecture();
             String archLabel = os.isWin() ? arch.toString() : "64";
             String osName = arch != ARM64 ? os.getName() : "arm";
-            String builtUrl = String.format(downloadUrlPattern, driverVersion,
-                    osName, archLabel);
+            String builtUrl = os == MAC && arch == ARM64 ?
+              String.format(downloadUrlPattern, driverVersion, "mac", "64_m1") :
+              String.format(downloadUrlPattern, driverVersion, osName, archLabel);
+
             log.debug("Using URL built from repository pattern: {}", builtUrl);
             try {
                 optionalUrl = Optional.of(new URL(builtUrl));

--- a/src/main/java/io/github/bonigarcia/wdm/managers/EdgeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/EdgeDriverManager.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import io.github.bonigarcia.wdm.config.Config;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.edge.EdgeOptions;
 
@@ -179,11 +180,15 @@ public class EdgeDriverManager extends WebDriverManager {
 
     @Override
     protected Optional<URL> buildUrl(String driverVersion) {
+        return buildUrl(driverVersion, config());
+    }
+
+    Optional<URL> buildUrl(String driverVersion, Config config) {
         Optional<URL> optionalUrl = empty();
-        if (!config().isUseMirror()) {
-            String downloadUrlPattern = config().getEdgeDownloadUrlPattern();
-            OperatingSystem os = config().getOperatingSystem();
-            Architecture arch = config().getArchitecture();
+        if (!config.isUseMirror()) {
+            String downloadUrlPattern = config.getEdgeDownloadUrlPattern();
+            OperatingSystem os = config.getOperatingSystem();
+            Architecture arch = config.getArchitecture();
             String archLabel = os.isWin() ? arch.toString() : "64";
             String osName = arch != ARM64 ? os.getName() : "arm";
             String builtUrl = String.format(downloadUrlPattern, driverVersion,

--- a/src/test/java/io/github/bonigarcia/wdm/config/DummyConfig.java
+++ b/src/test/java/io/github/bonigarcia/wdm/config/DummyConfig.java
@@ -1,0 +1,21 @@
+package io.github.bonigarcia.wdm.config;
+
+public class DummyConfig extends Config {
+  private final OperatingSystem operatingSystem;
+  private final Architecture arch;
+
+  public DummyConfig(OperatingSystem operatingSystem, Architecture arch) {
+    this.operatingSystem = operatingSystem;
+    this.arch = arch;
+  }
+
+  @Override
+  public OperatingSystem getOperatingSystem() {
+    return operatingSystem;
+  }
+
+  @Override
+  public Architecture getArchitecture() {
+    return arch;
+  }
+}

--- a/src/test/java/io/github/bonigarcia/wdm/managers/EdgeDriverManagerTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/managers/EdgeDriverManagerTest.java
@@ -1,0 +1,57 @@
+package io.github.bonigarcia.wdm.managers;
+
+import io.github.bonigarcia.wdm.config.DummyConfig;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static io.github.bonigarcia.wdm.config.Architecture.ARM64;
+import static io.github.bonigarcia.wdm.config.Architecture.DEFAULT;
+import static io.github.bonigarcia.wdm.config.Architecture.X32;
+import static io.github.bonigarcia.wdm.config.Architecture.X64;
+import static io.github.bonigarcia.wdm.config.OperatingSystem.LINUX;
+import static io.github.bonigarcia.wdm.config.OperatingSystem.MAC;
+import static io.github.bonigarcia.wdm.config.OperatingSystem.WIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EdgeDriverManagerTest {
+  private final EdgeDriverManager edgeDriverManager = new EdgeDriverManager();
+  private final String version = "106.0.1370.47";
+
+  @Test
+  void edgeVersionOnLinux() throws MalformedURLException {
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(LINUX, X32)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_linux64.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(LINUX, X64)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_linux64.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(LINUX, ARM64)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_arm64.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(LINUX, DEFAULT)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_linux64.zip"));
+  }
+  
+  @Test
+  void edgeVersionOnMac() throws MalformedURLException {
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, X32)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_mac64.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, X64)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_mac64.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, ARM64)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_arm64.zip")); // TODO incorrect URL! Should be edgedriver_mac64_m1.zip
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, DEFAULT)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_mac64.zip"));
+  }
+
+  @Test
+  void edgeVersionOnWindows() throws MalformedURLException {
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(WIN, X32)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_win32.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(WIN, X64)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_win64.zip"));
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(WIN, DEFAULT)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_winDEFAULT.zip")); // TODO seems to be incorrect
+    assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(WIN, ARM64)))
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_armARM64.zip")); // TODO seems to be incorrect
+  }
+}

--- a/src/test/java/io/github/bonigarcia/wdm/managers/EdgeDriverManagerTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/managers/EdgeDriverManagerTest.java
@@ -38,7 +38,7 @@ class EdgeDriverManagerTest {
     assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, X64)))
       .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_mac64.zip"));
     assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, ARM64)))
-      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_arm64.zip")); // TODO incorrect URL! Should be edgedriver_mac64_m1.zip
+      .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_mac64_m1.zip"));
     assertThat(edgeDriverManager.buildUrl(version, new DummyConfig(MAC, DEFAULT)))
       .hasValue(new URL("https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/106.0.1370.47/edgedriver_mac64.zip"));
   }


### PR DESCRIPTION
### Purpose of changes
Fix for https://github.com/bonigarcia/webdrivermanager/issues/897

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
1. I have added unit-tests covering all possible combinations of OS+Arch for EdgeDriver.
2. I tests the change manually on my Mac M1.

@bonigarcia I would say it's rather critical: WDM+Edge doesn't work on Macs.