### PR TITLE
Fix chrome image download on m1

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
@@ -16,6 +16,7 @@
  */
 package io.github.bonigarcia.wdm.managers;
 
+import static io.github.bonigarcia.wdm.config.Architecture.ARM64;
 import static io.github.bonigarcia.wdm.config.DriverManagerType.CHROME;
 import static java.util.Optional.empty;
 
@@ -29,6 +30,8 @@ import java.util.Optional;
 
 import javax.xml.namespace.NamespaceContext;
 
+import io.github.bonigarcia.wdm.config.Architecture;
+import io.github.bonigarcia.wdm.config.Config;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 
@@ -127,15 +130,19 @@ public class ChromeDriverManager extends WebDriverManager {
 
     @Override
     protected Optional<URL> buildUrl(String driverVersion) {
+        return buildUrl(driverVersion, config());
+    }
+
+    Optional<URL> buildUrl(String driverVersion, Config config) {
         Optional<URL> optionalUrl = empty();
-        if (!config().isUseMirror()) {
-            String downloadUrlPattern = config().getChromeDownloadUrlPattern();
-            OperatingSystem os = config().getOperatingSystem();
-            Architecture arch = config().getArchitecture();
+        if (!config.isUseMirror()) {
+            String downloadUrlPattern = config.getChromeDownloadUrlPattern();
+            OperatingSystem os = config.getOperatingSystem();
+            Architecture arch = config.getArchitecture();
             String archLabel = os.isWin() ? "32" : "64";
             String builtUrl = os.isMac() && ARM64.equals(arch) ?
-                String.format(downloadUrlPattern, driverVersion, os.getName(), String.format("_arm%s",archLabel)) :
-                String.format(downloadUrlPattern, driverVersion, os.getName(), archLabel);
+                    String.format(downloadUrlPattern, driverVersion, os.getName(), String.format("_arm%s",archLabel)) :
+                    String.format(downloadUrlPattern, driverVersion, os.getName(), archLabel);
             log.debug("Using URL built from repository pattern: {}", builtUrl);
             try {
                 optionalUrl = Optional.of(new URL(builtUrl));

--- a/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/ChromeDriverManager.java
@@ -131,9 +131,11 @@ public class ChromeDriverManager extends WebDriverManager {
         if (!config().isUseMirror()) {
             String downloadUrlPattern = config().getChromeDownloadUrlPattern();
             OperatingSystem os = config().getOperatingSystem();
-            String arch = os.isWin() ? "32" : "64";
-            String builtUrl = String.format(downloadUrlPattern, driverVersion,
-                    os.getName(), arch);
+            Architecture arch = config().getArchitecture();
+            String archLabel = os.isWin() ? "32" : "64";
+            String builtUrl = os.isMac() && ARM64.equals(arch) ?
+                String.format(downloadUrlPattern, driverVersion, os.getName(), String.format("_arm%s",archLabel)) :
+                String.format(downloadUrlPattern, driverVersion, os.getName(), archLabel);
             log.debug("Using URL built from repository pattern: {}", builtUrl);
             try {
                 optionalUrl = Optional.of(new URL(builtUrl));

--- a/src/test/java/io/github/bonigarcia/wdm/managers/ChromeDriverManagerTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/managers/ChromeDriverManagerTest.java
@@ -1,0 +1,53 @@
+package io.github.bonigarcia.wdm.managers;
+
+import io.github.bonigarcia.wdm.config.DummyConfig;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static io.github.bonigarcia.wdm.config.Architecture.*;
+import static io.github.bonigarcia.wdm.config.Architecture.ARM64;
+import static io.github.bonigarcia.wdm.config.OperatingSystem.*;
+import static io.github.bonigarcia.wdm.config.OperatingSystem.WIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChromeDriverManagerTest {
+    private static final String VERSION = "108.0.5359.22";
+    private final ChromeDriverManager chromeDriverManager = new ChromeDriverManager();
+    @Test
+    void chromeVersionOnLinux() throws MalformedURLException {
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(LINUX, X32)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(LINUX, X64)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(LINUX, ARM64)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(LINUX, DEFAULT)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", VERSION)));
+    }
+
+    @Test
+    void chromeVersionOnMac() throws MalformedURLException {
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(MAC, X32)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_mac64.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(MAC, X64)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_mac64.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(MAC, ARM64)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_mac_arm64.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(MAC, DEFAULT)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_mac64.zip", VERSION)));
+    }
+
+    @Test
+    void chromeVersionOnWindows() throws MalformedURLException {
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(WIN, X32)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_win32.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(WIN, X64)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_win32.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(WIN, DEFAULT)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_win32.zip", VERSION)));
+        assertThat(chromeDriverManager.buildUrl(VERSION, new DummyConfig(WIN, ARM64)))
+                .hasValue(new URL(String.format("https://chromedriver.storage.googleapis.com/%s/chromedriver_win32.zip", VERSION)));
+    }
+}


### PR DESCRIPTION
From version 106 the new chromedriver m1 image "version/chromedriver_mac_arm64.zip" eq: https://chromedriver.storage.googleapis.com/ 

Please have a look and let me know.

### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
