### PR TITLE
Create Config option to enable/disable Tracing for RemoteWebDriver, e…

### DIFF
--- a/src/doc/asciidoc/index.adoc
+++ b/src/doc/asciidoc/index.adoc
@@ -660,6 +660,7 @@ HTTP proxy. It can be also configured using the environment variable  `HTTPS_PRO
 |`clearResolutionCache()`|`wdm.clearResolutionCache` `=true`|`false` (not cleaning resolution cache)|Clean resolution cache
 |`ttl(int)`|`wdm.ttl`|`86400` (i.e., 1 day)|TTL in seconds in which the resolved driver versions are valid in the resolution cache.
 |`ttlBrowsers(int)`|`wdm.ttlForBrowsers`|`3600` (i.e., 1 hour)|TTL value in seconds in which the browser versions are valid in the resolution cache (also used for dockerized browsers).
+|`enableTracing` `disableTracing`|`wdm.tracing=false`|`true` (RemoteWebDriver tracing enabled by default)|Disable OpenTelemetry tracing for RemoteWebDriver
 |=======
 
 [[docker_config]]

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -541,6 +541,16 @@ public abstract class WebDriverManager {
         return this;
     }
 
+    public WebDriverManager enableTracing() {
+        config().setEnableTracing(true);
+        return this;
+    }
+
+    public WebDriverManager disableTracing() {
+        config().setEnableTracing(false);
+        return this;
+    }
+
     public WebDriverManager dockerRecordingPrefix(String prefix) {
         config().setDockerRecordingPrefix(prefix);
         return this;

--- a/src/main/java/io/github/bonigarcia/wdm/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/config/Config.java
@@ -272,6 +272,9 @@ public class Config {
     ConfigKey<String> browserWatcherVersion = new ConfigKey<>(
             "wdm.browserWatcherVersion", String.class);
 
+    ConfigKey<Boolean> tracing = new ConfigKey<Boolean>(
+            "wdm.tracing", Boolean.class);
+
     private <T> T resolve(ConfigKey<T> configKey) {
         String name = configKey.getName();
         T tValue = configKey.getValue();
@@ -1496,4 +1499,12 @@ public class Config {
         return this;
     }
 
+    public Config setEnableTracing(boolean value) {
+        this.tracing.setValue(value);
+        return this;
+    }
+
+    public Boolean getEnableTracing() {
+        return resolve(tracing);
+    }
 }

--- a/src/main/java/io/github/bonigarcia/wdm/webdriver/WebDriverCreator.java
+++ b/src/main/java/io/github/bonigarcia/wdm/webdriver/WebDriverCreator.java
@@ -86,7 +86,11 @@ public class WebDriverCreator {
                 log.trace("Requesting {} (the response code is {})", remoteUrl,
                         responseCode);
 
-                webdriver = new RemoteWebDriver(url, capabilities, config.getEnableTracing());
+                if (config.getEnableTracing()) {
+                    webdriver = new RemoteWebDriver(url, capabilities);
+                } else {
+                    webdriver = new RemoteWebDriver(url, capabilities, false);
+                }
             } catch (Exception e1) {
                 try {
                     log.trace("{} creating WebDriver object ({})",

--- a/src/main/java/io/github/bonigarcia/wdm/webdriver/WebDriverCreator.java
+++ b/src/main/java/io/github/bonigarcia/wdm/webdriver/WebDriverCreator.java
@@ -86,7 +86,7 @@ public class WebDriverCreator {
                 log.trace("Requesting {} (the response code is {})", remoteUrl,
                         responseCode);
 
-                webdriver = new RemoteWebDriver(url, capabilities);
+                webdriver = new RemoteWebDriver(url, capabilities, config.getEnableTracing());
             } catch (Exception e1) {
                 try {
                     log.trace("{} creating WebDriver object ({})",

--- a/src/main/resources/webdrivermanager.properties
+++ b/src/main/resources/webdrivermanager.properties
@@ -79,3 +79,5 @@ wdm.dockerLocalFallback=true
 wdm.dockerAvoidPulling=false
 
 wdm.browserWatcherVersion=1.2.0
+
+wdm.tracing=true

--- a/src/test/java/io/github/bonigarcia/wdm/test/properties/PropertiesTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/properties/PropertiesTest.java
@@ -72,6 +72,7 @@ class PropertiesTest {
         assertThat(config.isAvoidFallback()).isFalse();
         assertThat(config.isAvoidReadReleaseFromRepository()).isFalse();
         assertThat(config.isAvoidTmpFolder()).isFalse();
+        assertThat(config.getEnableTracing()).isTrue();
 
         assertThat(config.isClearResolutionCache()).isFalse();
         assertThat(config.isClearDriverCache()).isFalse();


### PR DESCRIPTION
Create new config parameter to allow for enabling/disabling of OpenTelemetry for RemoteWebDriver.

### Purpose of changes
Selenium Java introduced a parameter for RemoteWebDriver in [commit 3d21349](https://github.com/SeleniumHQ/selenium/commit/3d21349589c153ad5199815a5b4d1466fe333412) `boolean enableTracing` that allows the OpenTelemetry Tracing to be enabled or disabled. This feature is enabled by default and using WDM to create a RemoteWebDriver in fact correctly enables tracing. Consumers might want to use their own tracing or provide a more advanced OpenTelemetry config to Selenium, hence the introduction of the parameter. This change exposes this functionality to consumers of WDM.

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Documentation and default config added, also added relevant assert to PropertiesTest.java. Updated PropertiesTest runs successfully on my local env. Local test with changes as proposed correctly enables or disables tracing.
