### PR TITLE
Get Driver Version From Repository using Chrome Latest Versions list

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/config/Config.java
@@ -131,6 +131,8 @@ public class Config {
             "wdm.chromeGoodVersionsUrl", String.class);
     ConfigKey<String> chromeLastGoodVersionsUrl = new ConfigKey<>(
             "wdm.chromeLastGoodVersionsUrl", String.class);
+    ConfigKey<String> chromeLatestVersionsUrl = new ConfigKey<>(
+            "wdm.chromeLatestVersionsUrl", String.class);
 
     ConfigKey<String> edgeDriverVersion = new ConfigKey<>(
             "wdm.edgeDriverVersion", String.class);
@@ -809,6 +811,15 @@ public class Config {
 
     public Config setChromeLastGoodVersionsUrl(String value) {
         this.chromeLastGoodVersionsUrl.setValue(value);
+        return this;
+    }
+
+    public String getChromeLatestVersionsUrl() {
+        return resolve(chromeLatestVersionsUrl);
+    }
+
+    public Config setChromeLatestVersionsUrl(String value) {
+        this.chromeLatestVersionsUrl.setValue(value);
         return this;
     }
 

--- a/src/main/java/io/github/bonigarcia/wdm/versions/VersionDetector.java
+++ b/src/main/java/io/github/bonigarcia/wdm/versions/VersionDetector.java
@@ -89,7 +89,7 @@ public class VersionDetector {
     }
 
     public Optional<String> getDriverVersionFromProperties(String key) {
-        // Chromium values are the same than Chrome
+        // Chromium values are the same as Chrome
         if (key.contains("chromium")) {
             key = key.replace("chromium", "chrome");
         }
@@ -127,18 +127,18 @@ public class VersionDetector {
             try {
                 if (driverVersion.isPresent()
                         && Integer.parseInt(driverVersion.get()) >= 115) {
-                    // Parse JSON using GoodVersions
-                    cftUrl = config.getChromeGoodVersionsUrl();
+                    // Parse JSON using LatestVersions
+                    cftUrl = config.getChromeLatestVersionsUrl();
 
                     GoodVersions versions = Parser.parseJson(httpClient, cftUrl,
                             GoodVersions.class);
-                    List<Versions> fileteredList = versions.versions.stream()
+                    List<Versions> filteredList = versions.versions.stream()
                             .filter(v -> v.version
                                     .startsWith(driverVersion.get()))
                             .collect(toList());
 
-                    return Optional.of(fileteredList
-                            .get(fileteredList.size() - 1).version);
+                    return Optional.of(filteredList
+                            .get(filteredList.size() - 1).version);
                 } else if (!driverVersion.isPresent()) {
                     // Parse JSON using LastGoodVersions
                     cftUrl = config.getChromeLastGoodVersionsUrl();
@@ -161,7 +161,7 @@ public class VersionDetector {
             }
         }
 
-        String osLabel = optOsLabel.isPresent() ? optOsLabel.get() : "";
+        String osLabel = optOsLabel.orElse("");
         String url = driverVersion.isPresent()
                 ? driverUrl + latestLabel + "_" + driverVersion.get() + osLabel
                 : driverUrl + versionLabel;

--- a/src/main/resources/webdrivermanager.properties
+++ b/src/main/resources/webdrivermanager.properties
@@ -28,6 +28,7 @@ wdm.chromeDriverExport=webdriver.chrome.driver
 wdm.chromeDownloadUrlPattern=https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/%s/chromedriver-%s.zip
 wdm.chromeGoodVersionsUrl=https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
 wdm.chromeLastGoodVersionsUrl=https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json
+wdm.chromeLatestVersionsUrl=https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json
 
 wdm.geckoDriverUrl=https://raw.githubusercontent.com/bonigarcia/webdrivermanager/master/docs/mirror/geckodriver
 wdm.geckoDriverMirrorUrl=https://registry.npmmirror.com/-/binary/geckodriver/


### PR DESCRIPTION
Please ignore this PR. It needs to be fixed. (or you can fix it) Need to fix parsing for `latest-versions-per-milestone-with-downloads.json`

### Purpose of changes
need to use Chrome versions from https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json 
instead of 
https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
