### PR TITLE
Add explicit `commons-compress` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <docker-java.version>3.3.3</docker-java.version>
         <brotli.version>0.1.2</brotli.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>
+        <commons-compress.version>1.24.0</commons-compress.version>
         <httpclient5.version>5.2.1</httpclient5.version>
 
         <!-- provided -->
@@ -124,6 +125,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
### Purpose of changes
The library uses Apache Commons Compress: https://github.com/bonigarcia/webdrivermanager/blob/92569340383678a62e0d7bd111368423a188f9a1/src/main/java/io/github/bonigarcia/wdm/online/Downloader.java#L52-L53
but doesn't declare explicit dependency.

Everything works for now, because `org.apache.commons:commons-compress` is a transitive dependency coming from `com.github.docker-java:docker-java` -> `com.github.docker-java:docker-java-core` chain. 

But the issue appears when users exclude `docker-java` transitive dependency (e.g. to reduce classpath size when Docker features are not used). Also new issue may appear in future if `docker-java` changes its dependencies. In general that's a good approach to declare dependency on all libraries used in the code explicitly instead of relying on transitive dependencies.

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
