### PR TITLE
[Bugfix] #1129 unable to use chromeDownloadUrlPattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,12 @@
             <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -62,6 +62,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -1255,9 +1256,17 @@ public abstract class WebDriverManager {
         if (driverVersion.startsWith(".")) {
             driverVersion = driverVersion.substring(1);
         }
-        UrlHandler urlHandler = createUrlHandler(driverVersion);
-        URL url = urlHandler.getCandidateUrl();
-        downloadedDriverVersion = urlHandler.getDriverVersion();
+
+        URL url;
+        if (config.isAvoidExternalConnections()) {
+            url = URI.create(config.getChromeDownloadUrlPattern()).toURL();
+            downloadedDriverVersion = driverVersion;
+        } else {
+            UrlHandler urlHandler = createUrlHandler(driverVersion);
+            url = urlHandler.getCandidateUrl();
+            downloadedDriverVersion = urlHandler.getDriverVersion();
+        }
+
         return downloader.download(url, downloadedDriverVersion,
                 getDriverName(), getDriverManagerType());
     }

--- a/src/main/java/io/github/bonigarcia/wdm/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/wdm/config/Config.java
@@ -85,6 +85,8 @@ public class Config {
             Boolean.class);
     ConfigKey<Boolean> avoidShutdownHook = new ConfigKey<>(
             "wdm.avoidShutdownHook", Boolean.class);
+    ConfigKey<Boolean> avoidExternalConnections = new ConfigKey<>(
+            "wdm.avoidExternalConnections", Boolean.class);
     ConfigKey<Integer> timeout = new ConfigKey<>("wdm.timeout", Integer.class);
     ConfigKey<Boolean> versionsPropertiesOnlineFirst = new ConfigKey<>(
             "wdm.versionsPropertiesOnlineFirst", Boolean.class);
@@ -550,6 +552,15 @@ public class Config {
 
     public Config setAvoidShutdownHook(boolean value) {
         this.avoidShutdownHook.setValue(value);
+        return this;
+    }
+
+    public boolean isAvoidExternalConnections() {
+        return resolve(avoidExternalConnections);
+    }
+
+    public Config setAvoidExternalConnections(boolean value) {
+        this.avoidExternalConnections.setValue(value);
         return this;
     }
 

--- a/src/main/resources/webdrivermanager.properties
+++ b/src/main/resources/webdrivermanager.properties
@@ -10,6 +10,7 @@ wdm.avoidFallback=false
 wdm.avoidReadReleaseFromRepository=false
 wdm.avoidTmpFolder=false
 wdm.avoidShutdownHook=false
+wdm.avoidExternalConnections=false
 wdm.timeout=30
 wdm.resolutionCache=resolution.properties
 wdm.ttl=86400

--- a/src/test/java/io/github/bonigarcia/wdm/WebDriverManagerTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/WebDriverManagerTest.java
@@ -1,0 +1,81 @@
+package io.github.bonigarcia.wdm;
+
+import io.github.bonigarcia.wdm.config.Config;
+import io.github.bonigarcia.wdm.managers.VoidDriverManager;
+import io.github.bonigarcia.wdm.online.Downloader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WebDriverManagerTest {
+
+    @InjectMocks
+    private VoidDriverManager webDriverManager;
+
+    private MockedStatic<URI> uriMockedStatic;
+
+    @Mock
+    private Config config;
+
+    @Mock
+    private Downloader downloader;
+
+    @Mock
+    private URI uri;
+
+    @Mock
+    private URL url;
+
+    @BeforeEach
+    public void beforeEach() {
+        uriMockedStatic = mockStatic(URI.class);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        uriMockedStatic.close();
+    }
+
+    @DisplayName("download")
+    @ParameterizedTest(name = "with driver version {0} should download version {1}")
+    @MethodSource("valuesProvider")
+    void download(String driverVersion, String cleanDriverVersion, boolean avoidRemoteDownload) throws IOException {
+        String chromeDownloadUrlPattern = "https://chromeDownloadUrlPattern";
+        String expected = "expected";
+
+        when(config.isAvoidExternalConnections()).thenReturn(avoidRemoteDownload);
+        when(config.getChromeDownloadUrlPattern()).thenReturn(chromeDownloadUrlPattern);
+
+        when(URI.create(chromeDownloadUrlPattern)).thenReturn(uri);
+        when(uri.toURL()).thenReturn(url);
+
+        when(downloader.download(url, cleanDriverVersion, "", null)).thenReturn(expected);
+
+        assertEquals(expected, webDriverManager.download(driverVersion));
+    }
+
+    public static Stream<Arguments> valuesProvider() {
+        return Stream.of(
+                arguments("123", "123", true),
+                arguments(".123", "123", true)
+        );
+    }
+}

--- a/src/test/java/io/github/bonigarcia/wdm/WebDriverManagerTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/WebDriverManagerTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -18,11 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WebDriverManagerTest {
@@ -56,12 +54,13 @@ class WebDriverManagerTest {
 
     @DisplayName("download")
     @ParameterizedTest(name = "with driver version {0} should download version {1}")
-    @MethodSource("valuesProvider")
-    void download(String driverVersion, String cleanDriverVersion, boolean avoidRemoteDownload) throws IOException {
+    @ValueSource(strings = {"123", ".123"})
+    void download(String driverVersion) throws IOException {
         String chromeDownloadUrlPattern = "https://chromeDownloadUrlPattern";
         String expected = "expected";
+        String cleanDriverVersion = "123";
 
-        when(config.isAvoidExternalConnections()).thenReturn(avoidRemoteDownload);
+        when(config.isAvoidExternalConnections()).thenReturn(true);
         when(config.getChromeDownloadUrlPattern()).thenReturn(chromeDownloadUrlPattern);
 
         when(URI.create(chromeDownloadUrlPattern)).thenReturn(uri);
@@ -70,12 +69,5 @@ class WebDriverManagerTest {
         when(downloader.download(url, cleanDriverVersion, "", null)).thenReturn(expected);
 
         assertEquals(expected, webDriverManager.download(driverVersion));
-    }
-
-    public static Stream<Arguments> valuesProvider() {
-        return Stream.of(
-                arguments("123", "123", true),
-                arguments(".123", "123", true)
-        );
     }
 }


### PR DESCRIPTION
### Purpose of changes
Solution proposal for [issue 1129](https://github.com/bonigarcia/webdrivermanager/issues/1129)

### Types of changes

- [X ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Unit test pushed in this PR.
Also tested with a local demo project with this set:
`wdm.chromeDownloadUrlPattern=https://company_artifact/chrome-for-testing/%s/%s/chromedriver-%s.zip`
Outcomes:
1. Without any additional setting the issue is reproduced:
![Issue log](https://github.com/bonigarcia/webdrivermanager/assets/27963644/5d746d78-6392-49ee-a781-b7d162ddf449)

2. By setting `wdm.avoidExternalConnections=true`, the test fails since the url provided as `chromeDownloadUrlPattern` is fake, nevertheless no more "edgedl" occurrences are logged. (Proven also by debugging)
![Issue solved](https://github.com/bonigarcia/webdrivermanager/assets/27963644/0e9900c7-81fa-49ed-8d9e-02cd342b4724)

