### PR TITLE
Updated how we check if Docker is running to work with the new cgroup v2 system.

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -1882,7 +1882,7 @@ public abstract class WebDriverManager {
         WebDriverBrowser driverBrowser = new WebDriverBrowser();
         driverBrowser.addDockerContainer(browserContainer);
         driverBrowser.setSeleniumServerUrl(seleniumServerUrl);
-        log.trace("The Selenium Serverl URL is {}", seleniumServerUrl);
+        log.trace("The Selenium Server URL is {}", seleniumServerUrl);
         driverBrowser.setBrowserContainerId(browserContainer.getContainerId());
         webDriverList.add(driverBrowser);
 

--- a/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
+++ b/src/main/java/io/github/bonigarcia/wdm/docker/DockerService.java
@@ -151,11 +151,15 @@ public class DockerService {
         return host;
     }
 
-    public boolean isRunningInsideDocker() {
-        String[] commandArray = new String[] { "bash", "-c",
-                "cat /proc/self/cgroup | grep docker" };
+    private boolean isCommandResultPresent(String command) {
+        String[] commandArray = new String[] { "bash", "-c", command };
         String commandOutput = runAndWait(false, commandArray);
         return !isNullOrEmpty(commandOutput);
+    }
+
+    public boolean isRunningInsideDocker(){
+        return isCommandResultPresent("cat /proc/self/cgroup | grep docker") ||
+                isCommandResultPresent("cat /proc/self/mountinfo | grep docker/containers");
     }
 
     public String getDefaultHost() {


### PR DESCRIPTION
### Purpose of changes
While running CI tasks with Jenkins within a Docker environment, we encountered an unexpected behavior where the WDM returned the hostname as 'localhost' instead of the expected value. Upon further investigation, we discovered that the 'isRunningInsideDocker' method's command returned nothing when executed within a Docker container. This was attributed to the use of cgroup v2 on specific Linux operating systems, as the command is expected to only work with v1. Therefore, we identified and modified the command to be compatible with cgroup v2, and i anticipate that it will pass the validation checks correctly.

### Types of changes
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?

Setting up a testing environment on containers was very challenging. Instead, it will be replaced with the following resources.


Used a custom network, and the gateway is 172.20.0.1

Before the code change :
![스크린샷 2024-03-15 오전 12 33 12](https://github.com/bonigarcia/webdrivermanager/assets/112861844/ca72ad1d-9900-43f2-947a-8f7895b5f2f5)

After the code change :
![스크린샷 2024-03-15 오전 12 49 20](https://github.com/bonigarcia/webdrivermanager/assets/112861844/98fbe0f2-7c93-4108-963f-bca68d8ef9f9)

Confirmed that the results of the command are different inside and outside the container

Command Result (cgroup v2)

Inside Docker :
![스크린샷 2024-03-15 오전 12 59 55](https://github.com/bonigarcia/webdrivermanager/assets/112861844/4d12295b-340a-45e9-b754-65f78d73edb4)

Outside Docker:
![스크린샷 2024-03-15 오전 1 00 28](https://github.com/bonigarcia/webdrivermanager/assets/112861844/ab3393e4-8bed-4364-ad7e-63b0453f19d3)

Reference:
https://stackoverflow.com/questions/68816329/how-to-get-docker-container-id-from-within-the-container-with-cgroup-v2
https://docs.docker.com/config/containers/runmetrics/

