### PR TITLE
Increase compatibility with old versions Apache Commons

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WdmServer.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WdmServer.java
@@ -305,7 +305,7 @@ public class WdmServer {
             try (ClassicHttpResponse response = closeableHttpClient
                     .executeOpen(null, request, HttpClientContext.create())) {
                 responseContent = IOUtils
-                        .toString(response.getEntity().getContent(), UTF_8);
+                        .toString(response.getEntity().getContent(), UTF_8.name());
             }
         }
 

--- a/src/main/java/io/github/bonigarcia/wdm/versions/Shell.java
+++ b/src/main/java/io/github/bonigarcia/wdm/versions/Shell.java
@@ -77,7 +77,7 @@ public class Shell {
             Process process = new ProcessBuilder(command).directory(folder)
                     .redirectErrorStream(false).start();
             process.waitFor();
-            output = IOUtils.toString(process.getInputStream(), UTF_8);
+            output = IOUtils.toString(process.getInputStream(), UTF_8.name());
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug(

--- a/src/main/java/io/github/bonigarcia/wdm/versions/VersionDetector.java
+++ b/src/main/java/io/github/bonigarcia/wdm/versions/VersionDetector.java
@@ -169,7 +169,8 @@ public class VersionDetector {
         try (InputStream response = httpClient
                 .execute(httpClient.createHttpGet(new URL(url))).getEntity()
                 .getContent()) {
-            result = Optional.of(IOUtils.toString(response, versionCharset)
+            result = Optional.of(IOUtils.toString(response,
+                    (versionCharset != null ? versionCharset : Charset.defaultCharset()).name())
                     .replace("\r\n", ""));
         } catch (Exception e) {
             log.warn("Exception reading {} to get latest version of {} ({})",
@@ -347,7 +348,7 @@ public class VersionDetector {
                     propertiesName, online)) {
                 properties = new Properties();
                 properties.load(new StringReader(IOUtils
-                        .toString(inputStream, UTF_8).replace("\\", "\\\\")));
+                        .toString(inputStream, UTF_8.name()).replace("\\", "\\\\")));
                 propertiesMap.put(propertiesName, properties);
             } catch (Exception e) {
                 throw new IllegalStateException("Cannot read " + propertiesName,


### PR DESCRIPTION
Use [org.apache.commons.io.IOUtils.toString(InputStream, String)](https://github.com/apache/commons-io/blob/22a10912c7019b93abc9f701ca43a02e1fc47203/src/main/java/org/apache/commons/io/IOUtils.java#L3191) (available since 2.0) instead of [org.apache.commons.io.IOUtils.toString(InputStream, Charset)](https://github.com/apache/commons-io/blob/22a10912c7019b93abc9f701ca43a02e1fc47203/src/main/java/org/apache/commons/io/IOUtils.java#L3165) (available since 2.3)

### Purpose of changes
commons-io is a transitive dependency, used by docer-java and commons-compress. But webdrivermanager also uses this library without declaring it. In some cases methods are used, which have _non_-deprecated analogues in earlier commons-io versions. Usage of non-deprecated analogues allows to use wedrivermanager with earlier versions of commons-io (2.0-2.2 in this PR).
This PR is absolutely compatible with current functionality, has no additional requirement to client code.

### Types of changes
Compatibility extension without loss of functionality

### How has this been tested?
Use webdrivermanager in project with declared commons-io version 2.2.