### PR TITLE
Fix XXE vulnerability in XML parsing function

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/WebDriverManager.java
@@ -89,6 +89,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -1572,6 +1573,11 @@ public abstract class WebDriverManager {
             throws SAXException, IOException, ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
+
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setExpandEntityReferences(false);
+
         DocumentBuilder builder = factory.newDocumentBuilder();
         return builder.parse(new InputSource(
                 new ByteArrayInputStream(IOUtils.toByteArray(inputStream))));


### PR DESCRIPTION
**Description:**
This PR fixes an XXE vulnerability (CWE-611) in the loadXML() function, similar to the one fixed in the biojava project ([commit 1c94548](https://github.com/biojava/biojava/commit/1c94548cfa9fde74b970bcc0e4e07c073215524e)).
The fix adds factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true) and additional hardening to prevent attackers from exploiting XML parsing to access local files or perform SSRF attacks.

**References**
OWASP XXE Prevention: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
Original fix: https://github.com/biojava/biojava/commit/1c94548cfa9fde74b970bcc0e4e07c073215524e
Java XML Security Guide: https://docs.oracle.com/en/java/javase/11/security/java-api-xml-processing-jaxp-security-guide.html