### PR TITLE
Changed edge driver url

### DIFF
--- a/src/main/resources/webdrivermanager.properties
+++ b/src/main/resources/webdrivermanager.properties
@@ -40,7 +40,7 @@ wdm.operaDriverUrl=https://raw.githubusercontent.com/bonigarcia/webdrivermanager
 wdm.operaDriverMirrorUrl=https://registry.npmmirror.com/-/binary/operadriver/
 wdm.operaDriverExport=webdriver.chrome.driver
 
-wdm.edgeDriverUrl=https://msedgedriver.azureedge.net/
+wdm.edgeDriverUrl=https://msedgedriver.microsoft.com/
 wdm.edgeDriverExport=webdriver.edge.driver
 wdm.edgeDownloadUrlPattern=https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/%s/edgedriver_%s%s.zip
 


### PR DESCRIPTION
### Purpose of changes
[The url of edge driver is not working anymore](https://github.com/MicrosoftEdge/EdgeWebDriver/issues/200) we should use the new one.

### Types of changes
- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
This have been tested using the url as ENV: `WDM_EDGEDRIVERURL=https://msedgedriver.microsoft.com/` and works fine:
<img width="1485" height="263" alt="image" src="https://github.com/user-attachments/assets/6e0ee36f-9d48-4ccb-bfbf-c8e89b1fbe84" />

