### PR TITLE
#1469 consume process streams

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/versions/Shell.java
+++ b/src/main/java/io/github/bonigarcia/wdm/versions/Shell.java
@@ -126,7 +126,7 @@ public class Shell {
         }
 
         public static StreamReader consumeStderr(Process process) {
-            return consume(process.getInputStream(), "stderr");
+            return consume(process.getErrorStream(), "stderr");
         }
 
         public void run() {


### PR DESCRIPTION
### Purpose of changes
Address issue #1469 - Shell.runAndWaitNoLog() could cause hang

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
New class (StreamReader) for consuming launched process stdout and stderr streams has been tested independently with processes launched outside of WebDriverManager.
