### PR TITLE
adjust edge driver detection using listing.json

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/managers/EdgeDriverManager.java
+++ b/src/main/java/io/github/bonigarcia/wdm/managers/EdgeDriverManager.java
@@ -21,8 +21,6 @@ import static io.github.bonigarcia.wdm.config.DriverManagerType.EDGE;
 import static io.github.bonigarcia.wdm.config.OperatingSystem.MAC;
 import static java.util.Locale.ROOT;
 import static java.util.Optional.empty;
-import static javax.xml.xpath.XPathConstants.NODESET;
-import static javax.xml.xpath.XPathFactory.newInstance;
 import static org.apache.commons.io.FileUtils.listFiles;
 
 import java.io.File;
@@ -31,30 +29,20 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import javax.xml.namespace.NamespaceContext;
-import javax.xml.xpath.XPath;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.net.URIBuilder;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.edge.EdgeOptions;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.Architecture;
 import io.github.bonigarcia.wdm.config.Config;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
 import io.github.bonigarcia.wdm.config.OperatingSystem;
-import io.github.bonigarcia.wdm.config.WebDriverManagerException;
+import io.github.bonigarcia.wdm.online.EdgeDriverListing;
+import io.github.bonigarcia.wdm.online.Parser;
 import io.github.bonigarcia.wdm.webdriver.OptionsWithArguments;
 
 /**
@@ -65,8 +53,8 @@ import io.github.bonigarcia.wdm.webdriver.OptionsWithArguments;
  */
 public class EdgeDriverManager extends WebDriverManager {
 
+    private static final String LISTING_JSON = "listing.json";
     protected static final String LATEST_STABLE = "LATEST_STABLE";
-    protected static final String STORAGE_QUERY = "?restype=container&comp=list";
 
     @Override
     public DriverManagerType getDriverManagerType() {
@@ -135,8 +123,21 @@ public class EdgeDriverManager extends WebDriverManager {
 
     @Override
     protected List<URL> getDriverUrls(String driverVersion) throws IOException {
-        return getDriversFromXml(new URL(getDriverUrl() + STORAGE_QUERY),
-                "//Blob/Name", empty());
+        //driverVersion is obsolete here same as in ChromeDriverManager.
+        //it is used at WebDriverManager.getDriverVersions
+
+        String listingUrl = config().getEdgeDriverUrl() + LISTING_JSON;
+        EdgeDriverListing listing = Parser.parseJson(getHttpClient(), listingUrl, EdgeDriverListing.class);
+
+        return Arrays.stream(listing.items)
+                .filter(item -> !item.isDirectory)
+                .map(item -> {
+                    try {
+                        return new URL(config().getEdgeDriverUrl() + item.name);
+                    } catch (MalformedURLException e) {
+                        throw new WebDriverException("Incorrect EdgeDriver URL: " + item.name);
+                    }
+                }).collect(Collectors.toList());
     }
 
     @Override
@@ -256,54 +257,6 @@ public class EdgeDriverManager extends WebDriverManager {
     public WebDriverManager exportParameter(String exportParameter) {
         config().setEdgeDriverExport(exportParameter);
         return this;
-    }
-
-    protected List<URL> getDriversFromXml(URL driverUrl, String xpath,
-            Optional<NamespaceContext> namespaceContext) throws IOException {
-        logSeekRepo(driverUrl);
-        List<URL> urls = new ArrayList<>();
-        try {
-            try (ClassicHttpResponse response = getHttpClient()
-                    .execute(getHttpClient().createHttpGet(driverUrl))) {
-                Document xml = loadXML(response.getEntity().getContent());
-                XPath xPath = newInstance().newXPath();
-                if (namespaceContext.isPresent()) {
-                    xPath.setNamespaceContext(namespaceContext.get());
-                }
-                NodeList nodes = (NodeList) xPath.evaluate(xpath,
-                        xml.getDocumentElement(), NODESET);
-                for (int i = 0; i < nodes.getLength(); ++i) {
-                    Element e = (Element) nodes.item(i);
-                    urls.add(new URL(driverUrl.toURI().resolve(".")
-                            + e.getChildNodes().item(0).getNodeValue()));
-                }
-
-                NodeList nextMarkerNodes = (NodeList) xPath.evaluate(
-                        "/EnumerationResults/NextMarker",
-                        xml.getDocumentElement(), NODESET);
-                if (nextMarkerNodes.getLength() > 0) {
-                    String containerName = String.format("%s://%s/",
-                            driverUrl.getProtocol(), driverUrl.getAuthority());
-                    Element e = (Element) nextMarkerNodes.item(0);
-                    if (e.hasChildNodes()) {
-                        String marker = e.getFirstChild().getNodeValue();
-                        if (StringUtils.isNotEmpty(marker)) {
-                            urls.addAll(getDriversFromXml(
-                                    new URIBuilder(
-                                            containerName + STORAGE_QUERY)
-                                                    .setParameter("marker",
-                                                            marker)
-                                                    .build().toURL(),
-                                    xpath, namespaceContext));
-                        }
-                    }
-                }
-
-            }
-        } catch (Exception e) {
-            throw new WebDriverManagerException(e);
-        }
-        return urls;
     }
 
 }

--- a/src/main/java/io/github/bonigarcia/wdm/online/EdgeDriverListing.java
+++ b/src/main/java/io/github/bonigarcia/wdm/online/EdgeDriverListing.java
@@ -1,0 +1,14 @@
+package io.github.bonigarcia.wdm.online;
+
+public class EdgeDriverListing {
+
+    public EdgeDriverItem[] items;
+
+    public class EdgeDriverItem {
+        public boolean isDirectory;
+        public String name;
+        public long contentLength;
+        public String lastModified;
+    }
+
+}

--- a/src/test/java/io/github/bonigarcia/wdm/test/edge/EdgeLatestVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/edge/EdgeLatestVersionTest.java
@@ -78,4 +78,22 @@ class EdgeLatestVersionTest {
         }
     }
 
+    @Test
+    void testAvoidExternalConnections() {
+        WebDriverManager wdm = WebDriverManager.edgedriver()
+                .forceDownload() // force download to prevent caches
+                .avoidExternalConnections()
+                .win()
+                .avoidBrowserDetection();
+
+        wdm.setup();
+
+        assertThat(wdm.getDownloadedDriverVersion()).isNotNull();
+        log.debug("Downloaded EdgeDriver version: {}",
+                wdm.getDownloadedDriverVersion());
+
+        List<String> driverVersions = wdm.getDriverVersions();
+        assertThat(driverVersions).isNotEmpty();
+        log.debug("Driver versions from listing: {}", driverVersions);
+    }
 }

--- a/src/test/java/io/github/bonigarcia/wdm/test/edge/EdgeVersionTest.java
+++ b/src/test/java/io/github/bonigarcia/wdm/test/edge/EdgeVersionTest.java
@@ -37,5 +37,4 @@ class EdgeVersionTest extends VersionTestParent {
         os = WIN;
         specificVersions = new String[] { "125.0.2535.92" };
     }
-
 }


### PR DESCRIPTION
### Purpose of changes
Due to change at https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/, it is not possible to get edgedriver.xml and parse urls. Thus https://msedgedriver.microsoft.com/listing.json is used to get and parse versions

https://github.com/bonigarcia/webdrivermanager/issues/1575

### Types of changes
Migrate from XML file to JSON file parsing

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
io.github.bonigarcia.wdm.test.edge.EdgeLatestVersionTest#testAvoidExternalConnections
