### PR TITLE
Bump dependency version of httpclient5 from 5.6 to 5.6.1 to address CVE-2026-40542

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <brotli.version>0.1.2</brotli.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-compress.version>1.28.0</commons-compress.version>
-        <httpclient5.version>5.6</httpclient5.version>
+        <httpclient5.version>5.6.1</httpclient5.version>
 
         <!-- provided -->
         <selenium.version>4.44.0</selenium.version>


### PR DESCRIPTION

### Purpose of changes
Bump org.apache.httpcomponents.client5:httpclient5 from 5.6 to 5.6.1 

### Types of changes

- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Sources have been built, tests have run, but docker tests fail with privacy error!.
